### PR TITLE
Added workspace base for training

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -41,6 +41,7 @@ WCS_PASSWORD_ITEM = 'password'
 WCS_CREDS_SECTION = 'ASSISTANT CREDENTIALS'
 
 SPEC_FILENAME = 'workspace.json'
+WORKSPACE_BASE_FILENAME = 'workspace_base.json'
 
 current_file_path = os.path.dirname(__file__)
 # Sub-script paths

--- a/workspaceParser.py
+++ b/workspaceParser.py
@@ -18,9 +18,11 @@
 """
 import os
 import csv
+import json
 from argparse import ArgumentParser
 from watson_developer_cloud import AssistantV1
-from utils import WCS_VERSION, TRAIN_INTENT_FILENAME, TRAIN_ENTITY_FILENAME
+from utils import WCS_VERSION, TRAIN_INTENT_FILENAME, TRAIN_ENTITY_FILENAME, \
+                  WORKSPACE_BASE_FILENAME
 
 
 def func(args):
@@ -29,11 +31,16 @@ def func(args):
     workspace = conv.get_workspace(workspace_id=args.workspace_id, export=True)
     intent_train_file = os.path.join(args.outdir, TRAIN_INTENT_FILENAME)
     entity_train_file = os.path.join(args.outdir, TRAIN_ENTITY_FILENAME)
+    workspace_file = os.path.join(args.outdir, WORKSPACE_BASE_FILENAME)
 
     intent_exports = workspace['intents']
     entity_exports = workspace['entities']
     if len(intent_exports) == 0:
         raise ValueError("No intent is found in workspace")
+
+    # Save workspace json
+    with open(workspace_file, 'w+') as file:
+        json.dump(workspace, file)
 
     # Parse intents to file
     with open(intent_train_file, 'w+') as csvfile:


### PR DESCRIPTION
DCO 1.1 Signed-off-by: Xinyun Zhao Victor.Zhao@ibm.com

By applying exported workspace JSON as the training base, the candidate workspaces may use other metadata except the provided data, for example, dialog nodes, counter examples and so on.