### PR TITLE
Add configparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn>=0.19.1
 scipy>=1.0.0
 matplotlib>=2.1.2
 aiohttp>=3.4
+configparser


### PR DESCRIPTION
Code update for #34 

Without `configparser` in my requirements.txt, or even in `pip list`, I was able to run the k-folds tool.  I assume it was pulled in from somewhere else.

For completeness I tested with installing `configparser-3.7.4`, the latest available when I ran `pip install configparser`

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>