### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 config.ini
-data/
+data/*
+!data/workspace_base.json.sample
 __pycache__/
 .vscode
 


### PR DESCRIPTION
workspace_base.json.sample is needed to make the scripts run
if you push this repo in to an other it will skip the sample, and if someone clones that they would not have this .sample file that run.py needs