### PR TITLE
Check for empty vgwCommands list

### DIFF
--- a/validate_workspace/validateWS.py
+++ b/validate_workspace/validateWS.py
@@ -138,7 +138,7 @@ def validateVoiceGatewayCommands(dialogNode:DialogNode, expectedVoiceGatewayComm
     text = dialogNode.getText()
     if text != "" and 'jump_to' != dialogNode.getNextStep():
         vgwCommands = dialogNode.getVoiceGatewayCommands()
-        if vgwCommands == None:
+        if vgwCommands == None or len(vgwCommands) == 0:
             print("WARN:\t{}\tDoes not contain any Voice Gateway commands".format(dialogNode.getId()))
         else:
             for expected_command in expectedVoiceGatewayCommands:


### PR DESCRIPTION
DCO 1.1 Signed-off-by: Leo Mazzoli <lmazzoli@us.ibm.com>

Updated the validateWA.py file to check for vgwCommands == None or len(vgwCommands) == 0 when checking for the existence of voice gateway commands.  

When there was an output section in the node response, but the node did NOT contain the vgwActionSequence, the vgwCommands list is coming back as empty (but not Null).  