### PR TITLE
Extract user utterances

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ There are a variety of ways to use this tool.  Primarily you will execute a k-fo
 
 [Generate long-tail classification results](examples/long-tail-scoring.md)
 
+[Run syntax validation patterns on a workspace](validate_workspace/README.md)
+
+[Extract utterances leading to a dialog node](extract_utterances/README.md)
+
 ## Caveats and Troubleshooting
 Due to different coverage among service plans, user may need to adjust `max_test_rate` accordingly to avoid network connection error.
 

--- a/extract_utterances/README.md
+++ b/extract_utterances/README.md
@@ -1,0 +1,36 @@
+## getUtteranceBeforeNode.py
+This tool extracts user utterances from Watson Assistant logs.
+The purpose of this tool is to find user utterances containing intents that can be analyzed further.
+
+Given a list of intent-based utterances it is possible to
+Test accuracy: Create a "blind" test file by adding a column with a "golden intent" for each utterance, then running WA-Testing-Tool in blind mode.
+Improve training: Inspect utterances for new intents/entities that may need to be added.
+
+*Prerequisite steps*
+
+Gather the information needed to connect to your workspace (apikey, URL, and workspace ID)
+
+Gather the node ID to analyze.  For each conversation that hits this node you will get the user utterance directly before this node fired.
+
+*Execution steps*
+
+You are required to provide:
+* Arguments to connect to your workspace (apikey `-a`, workspace_id `-w`, and optionally url `-l`)
+
+You may optionally provide
+* A node ID to analyze (node_ID `-n`, default is `anything_else`)
+* Output type (columns `-c`, `all` or `utterance`, default is `utterance`)
+* Output filename (file `-o`, default is to print to screen)
+* Maximum results (page limit `-p`, default is 100)
+
+Example execution:
+
+```
+python getUtteranceBeforeNode.py -n node_1_1234567890123 -a 1111222233334444555566667777888899990000 -w 11111111-2222-3333-4444-555566667777 -l https://gateway-wdc.watsonplatform.net/assistant/api -c all -o output.tsv
+```
+
+You can print the help using the following command:
+
+```
+python getUtteranceBeforeNode.py -h
+```

--- a/extract_utterances/getUtteranceBeforeNode.py
+++ b/extract_utterances/getUtteranceBeforeNode.py
@@ -1,0 +1,71 @@
+import sys
+import json
+from argparse import ArgumentParser
+from watson_developer_cloud import AssistantV1
+
+WCS_VERSION='2018-09-20'
+DEFAULT_PAGE_LIMIT=100
+
+def getAssistant(iam_apikey, url):
+    c = AssistantV1(iam_apikey=iam_apikey, version=WCS_VERSION, url=url)
+    return c
+
+
+def getLogs(assistant, workspace_id, node_id, page_limit):
+    filter = 'response.output.nodes_visited::{}'.format(node_id)
+    output = assistant.list_logs(workspace_id=workspace_id, sort='-request_timestamp', filter=filter, page_limit=page_limit)
+
+    #Hack for API compatibility between v1 and v2 of the API - v2 adds a 'result' property on the response.  v2 simplest form is list_logs().get_result()
+    output = json.loads(str(output))
+    if 'result' in output:
+       logs = output['result']
+    else:
+       logs = output
+
+    if 'logs' in logs:
+       return logs['logs']
+    else:
+       return None
+
+def outputLogs(logs, output_columns, output_file):
+    if output_file != None:
+       file = open(output_file,'w')
+
+    for log in logs:
+       utterance  = log['request' ]['input']['text']
+       intent     = log['response']['intents'][0]['intent']
+       confidence = log['response']['intents'][0]['confidence']
+
+       if 'all' == output_columns:
+          output_line = '{}\t{}\t{}'.format(utterance, intent, confidence)
+       else:
+          #assumed just 'utterance'
+          output_line = utterance
+
+       if output_file != None:
+          file.write(output_line + '\n')
+       else:
+          print(output_line)
+
+    if output_file != None:
+       file.close()
+
+def create_parser():
+    parser = ArgumentParser(description='Gathers user inputs that led to a given dialog node')
+    parser.add_argument('-n', '--node_id', type=str, help='ID of the node where you want the user input that directly led to this node, default is "anything_else"', default='anything_else')
+    parser.add_argument('-c', '--output_columns', type=str, help='Which columns you want in output, either "utterance" or "all" (default is "utterance")', default='utterance')
+    parser.add_argument('-o', '--output_file', type=str, help='Filename to write results to')
+    parser.add_argument('-w', '--workspace_id', type=str, help='Workspace identifier', required=True)
+    parser.add_argument('-a', '--iam_apikey', type=str, required=True, help='Assistant service iam api key')
+    parser.add_argument('-p', '--page_limit', type=int, default=DEFAULT_PAGE_LIMIT, help='Number of results downloaded per page (default is 1 page with max {} results in that page)'.format(DEFAULT_PAGE_LIMIT))
+    parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/assistant/api',
+                        help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
+
+    return parser
+
+if __name__ == '__main__':
+   ARGS = create_parser().parse_args()
+
+   service = getAssistant(ARGS.iam_apikey,ARGS.url)
+   logs    = getLogs(service, ARGS.workspace_id, ARGS.node_id, ARGS.page_limit)
+   outputLogs(logs, ARGS.output_columns, ARGS.output_file)


### PR DESCRIPTION
Connects to a workspace and extracts conversation "logs" matching a criteria then builds a report.
The criteria is a dialog node ID.
The report includes a list of user utterances immediately prior to accessing that dialog node (one utterance per conversation)

Solves #76 

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>