### PR TITLE
Configuration enhancements: reduction of required and addition of API version

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -27,7 +27,6 @@ mode = kfold
 
 ; (Optional) All output files will be stored here. Default is `./data` (formerly called `temporary_file_directory`)
 ;output_directory = ./data
-;temporary_file_directory = ./data
 
 ; (Optional) yes/no on whether to keep(yes) or delete(no) workspaces created by this tool after the testing phase. Default is 'no'
 ;keep_workspace_after_test = no

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -8,6 +8,9 @@ password =
 iam_apikey =
 url = https://gateway.watsonplatform.net/assistant/api
 
+;API version, default is 2019-02-28, specify the version matching your Watson Assistant
+;version=
+
 [DEFAULT]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Required parameters independent of mode

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,59 +1,3 @@
-[DEFAULT]
-; (Required) One of:
-; Workspace ID (can be found on Watson Assistant UI - navigate to Skills tab and click three dots for View API Details)
-; Path to JSON file representing the locally saved workspace
-workspace_id = <workspace_id or workspace JSON>
-
-; (Required) Test request rate (maximum number of API calls per second)
-max_test_rate = 100
-
-; (Required) All temporary files will be stored here
-temporary_file_directory = ./data
-
-; (Required) yes/no on whether to keep(yes) or delete(no) workspaces created by this tool after the testing phase
-keep_workspace_after_test = no
-
-; (Required) Mode to run tool in.  This setting affects which other variables are required in the rest of the DEFAULT section.
-; Value values: KFOLD, BLIND or TEST
-mode = kfold
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; The remaining parameters in DEFAULT section depend upon the MODE above
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; (Required for blind and test) Test input file. blind mode requires two columns, test mode requires one column
-; In blind mode column headers are 'utterance' and 'golden intent'
-; In test mode column header is 'utterance'
-test_input_file = ./data/test.csv
-
-; (Required for blind and test) Test output path
-test_output_path = ./data/test-out.csv
-
-; (Required for blind and kfold) Output figure path
-out_figure_path= ./data/figure.png
-
-; (Required for kfold) Number of folds.  If on LITE plan use 3.
-; Each fold creates a workspace (make sure you have enough workspaces available, LITE plans are restricted to 5)
-fold_num = 5
-
-; (Required for blind) Title for blind testing output figure
-blind_figure_title = 'Blind Test Results'
-
-; (Optional for blind and kfold) Threshold of confidence for classification, below which an answer is automatically wrong
-; Default value is 0.2 if not specified. (Watson Assistant automatically classifies as "#Irrelevant" below 0.2)
-conf_thres = 0.2
-
-; (Optional for blind and kfold) Path to Partial Credit Table
-; partial_credit_table = ./data/partial-credit-table.csv
-
-; (Optional for blind and kfold) Weighting scheme for result scoring.
-; Valid values: POPULATION (default), EQUAL or WEIGHT_FILE (path to a weights CSV file)
-weight_mode = population
-
-; (Optional for blind) Previous blind test output file, for comparing consecutive blind tests
-; For simplicity use a file created by this tool on a previous run
-; previous_blind_out = ./data/prev-test-out.csv
-
 [ASSISTANT CREDENTIALS]
 ; Regardless of mode you must specify a WA environment to test the classification against.
 ; If your WA environment provides username and password, configure them and leave iam_apikey empty
@@ -63,3 +7,68 @@ username =
 password =
 iam_apikey =
 url = https://gateway.watsonplatform.net/assistant/api
+
+[DEFAULT]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Required parameters independent of mode
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; (Required) One of:
+; Workspace ID (can be found on Watson Assistant UI - navigate to Skills tab and click three dots for View API Details)
+; Path to JSON file representing the locally saved workspace
+workspace_id = <workspace_id or workspace JSON>
+
+; (Required) Mode to run tool in.  This setting affects which other variables are required in the rest of the DEFAULT section.
+; Value values: KFOLD, BLIND or TEST
+mode = kfold
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Optional parameters independent of mode
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; (Optional) All output files will be stored here. Default is `./data` (formerly called `temporary_file_directory`)
+;output_directory = ./data
+;temporary_file_directory = ./data
+
+; (Optional) yes/no on whether to keep(yes) or delete(no) workspaces created by this tool after the testing phase. Default is 'no'
+;keep_workspace_after_test = no
+
+; (Required) Test request rate (maximum number of API calls per second). Default is 100.
+;max_test_rate = 100
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; The remaining parameters in DEFAULT section depend upon the MODE above
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; (Optional for blind and test) Test input file. Defaults to <temporary_file_directory>/input.csv
+; blind mode requires two columns, test mode requires one column
+;   In blind mode column headers are 'utterance' and 'golden intent'
+;   In test mode column header is 'utterance'
+; test_input_file = ./data/test.csv
+
+; (Optional for blind and test) Test output path. Defaults to <temp_dir>/<mode>-out.csv
+; test_output_path = ./data/test-out.csv
+
+; (Optional for blind and kfold) Output figure path. Defaults to <temp_dir>/<mode>.jpg
+; out_figure_path= ./data/figure.png
+
+; (Optional for kfold) Number of folds.  If on LITE plan use 3. Default is 5.
+; Each fold creates a workspace (make sure you have enough workspaces available, LITE plans are restricted to 5)
+; fold_num = 5
+
+; (Optional for blind) Title for blind testing output figure. Default is 'Blind Test Results'
+; blind_figure_title = 'Blind Test Results'
+
+; (Optional for blind and kfold) Threshold of confidence for classification, below which an answer is automatically wrong
+; Default value is 0.2 if not specified. (Watson Assistant automatically classifies as "#Irrelevant" below 0.2)
+; conf_thres = 0.2
+
+; (Optional for blind and kfold) Path to Partial Credit Table
+; partial_credit_table = ./data/partial-credit-table.csv
+
+; (Optional for blind and kfold) Weighting scheme for result scoring.
+; Valid values: POPULATION (default), EQUAL or WEIGHT_FILE (path to a weights CSV file)
+; weight_mode = population
+
+; (Optional for blind) Previous blind test output file, for comparing consecutive blind tests
+; For simplicity use a file created by this tool on a previous run
+; previous_blind_out = ./data/prev-test-out.csv

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -41,7 +41,7 @@ mode = kfold
 ; The remaining parameters in DEFAULT section depend upon the MODE above
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; (Optional for blind and test) Test input file. Defaults to <temporary_file_directory>/input.csv
+; (Optional for blind and test) Test input file. Defaults to <output_directory>/input.csv
 ; blind mode requires two columns, test mode requires one column
 ;   In blind mode column headers are 'utterance' and 'golden intent'
 ;   In test mode column header is 'utterance'

--- a/examples/blind.md
+++ b/examples/blind.md
@@ -18,6 +18,7 @@ username = <wa username>
 password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
+version=2019-02-28
 
 [DEFAULT]
 mode = blind

--- a/examples/blind.md
+++ b/examples/blind.md
@@ -3,7 +3,7 @@
 Given a training set of Watson Assistant utterances mapped to intents with optional entities set, the user wants to test its performance by using a blind set.
 
 ## Workflow
-Unlike k-fold process, no separate folds will be created. Only one workspace is going to be trained using all of the training set. After the testing, both the test output and the `previous_test_out` are feed into `createPrecisionCurve.py` for plotting curves.
+Unlike k-fold process, no separate folds will be created. Only one workspace is going to be trained using all of the training set. After the testing, both the test output and the `previous_test_out` are fed into `createPrecisionCurve.py` for plotting curves.
 
 Further, reports are generated for an [intent metrics summary](intent-metrics.md) and a [confusion matrix](confusion-matrix.md).  These include additional summaries and visualizations that help determine the strength and weaknesses of the training set.
 
@@ -11,21 +11,6 @@ Further, reports are generated for an [intent metrics summary](intent-metrics.md
 `config.ini`
 
 ```
-[DEFAULT]
-mode = BLIND
-workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
-test_input_file = ./data/test.csv
-blind_figure_title = <figure name>
-; optional
-previous_blind_out = ./data/previous_blind_out.csv
-test_output_path = ./data/test-out.csv
-temporary_file_directory = ./data
-; Figure path for kfold and blind test
-out_figure_path= ./data/figure.png
-; Clean the workspaces after testing
-keep_workspace_after_test = no
-
-
 [ASSISTANT CREDENTIALS]
 ; If your WA environment provides username and password, configure them and leave iam_apikey empty
 ; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
@@ -34,9 +19,23 @@ password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
 
+[DEFAULT]
+mode = blind
+workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
+
+; Provide when comparing to a previous blind test result
+;previous_blind_out = ./data/previous_blind_out.csv
+
+; optional - defaults shown here
+;output_directory = ./data
+;test_input_file = ./data/input.csv
+;blind_figure_title = "<igure name"
+;test_output_path = ./data/blind-out.csv
+;out_figure_path= ./data/blind.png
+;keep_workspace_after_test = no
 ```
 
-`test_input_file` - Blind test set.
+`test_input_file` - Blind test set. Defaults `./data/input.csv`. Should have columns `utterance` and `golden intent`
 
 `previous_blind_out` - (Optional) Test output from previous blind test result.
 

--- a/examples/kfold.md
+++ b/examples/kfold.md
@@ -15,17 +15,6 @@ User's workspace must allow to create 5 more workspaces. For 'lite' plans, use 3
 `config.ini`
 
 ```
-[DEFAULT]
-mode = KFOLD
-workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
-temporary_file_directory = ./data
-out_figure_path= ./data/figure.png
-; number of folds
-fold_num = 5
-; Clean the workspaces after testing
-keep_workspace_after_test = no
-
-
 [ASSISTANT CREDENTIALS]
 ; If your WA environment provides username and password, configure them and leave iam_apikey empty
 ; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
@@ -33,7 +22,22 @@ username = <wa username>
 password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
+
+[DEFAULT]
+mode = kfold
+workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
+
+; optional - defaults shown here
+;fold_num = 5
+;output_directory = ./data
+;out_figure_path= ./data/figure.png
+;conf_thres = 0.2
 ```
 
 ## Sample output
 ![KFold curves](../resources/kfold-curves.png)
+
+## Troubleshooting
+The most common error running a k-folds test is running out of available workspaces, particularly if you are on a Lite plan which limits you to 5 workspaces.  The k-folds test creates `fold_num` workspaces.
+
+If you run out of workspaces, delete any unused workspaces and reduce the `fold_num` parameter to a smaller value (ex: `fold_num=3`).

--- a/examples/kfold.md
+++ b/examples/kfold.md
@@ -22,6 +22,7 @@ username = <wa username>
 password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
+version=2019-02-28
 
 [DEFAULT]
 mode = kfold

--- a/examples/long-tail-scoring.md
+++ b/examples/long-tail-scoring.md
@@ -8,7 +8,7 @@ There are two starting possibilities:
 
 1) The user has run existing [k-folds](kfold.md), [test](standard-test.md), or [blind](blind.md) test which creates a summary .csv file
 
-2) The user has a separate analysis which creates a .csv file with "golden", "predicted", and "confidence" columns 
+2) The user has a separate analysis which creates a .csv file with "golden", "predicted", and "confidence" columns
 
 User executes `longtailscoring.py` providing an input filename and output filename.  If using workflow 2, the user provides the names of the golden, predicted, and confidence column header names with `-g`, `-t`, and `-c` respectively.
 The summary is written to the output filename.
@@ -20,10 +20,10 @@ User must have an input .csv file containing at least three column headers repre
 
 ## Invocation
 Workflow #1
-Assuming input file at `data/test-out.csv` created by other tools in this repository and writing to `test-out-metrics.csv'. 
+Assuming input file at `data/blind-out.csv` created by other tools in this repository and writing to `blind-out-metrics.csv'.
 
 ```
-python utils/longtailscoring.py -i data/test-out.csv -o data/test-out-metrics.csv
+python utils/longtailscoring.py -i data/blind-out.csv -o data/blind-out-metrics.csv
 ```
 
 Workflow #2

--- a/examples/standard-test.md
+++ b/examples/standard-test.md
@@ -16,6 +16,7 @@ username = <wa username>
 password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
+version=2019-02-28
 
 [DEFAULT]
 mode = test

--- a/examples/standard-test.md
+++ b/examples/standard-test.md
@@ -9,16 +9,6 @@ There is one and only one column in `test_input_file.csv` containing the test ut
 `config.ini`
 
 ```
-[DEFAULT]
-mode = TEST
-workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
-test_input_file = ./data/test.csv
-test_output_path = ./data/test-out.csv
-temporary_file_directory = ./data
-; Clean the workspaces after testing
-keep_workspace_after_test = no
-
-
 [ASSISTANT CREDENTIALS]
 ; If your WA environment provides username and password, configure them and leave iam_apikey empty
 ; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
@@ -27,8 +17,18 @@ password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
 
+[DEFAULT]
+mode = test
+workspace_id = 01234567-9ABC-DEF0-1234-56789ABCDEF0
+
+; optional - defaults shown here
+;output_directory = ./data
+;test_input_file = ./data/input.csv
+;test_output_path = ./data/test-out.csv
+;keep_workspace_after_test = no
 ```
-`test_input_file.csv`
+
+Sample `test_input_file.csv`
 
 | utterance   |
 | ----------- |

--- a/run.py
+++ b/run.py
@@ -27,7 +27,7 @@ from watson_developer_cloud import AssistantV1
 from utils import TRAIN_FILENAME, TEST_FILENAME, UTTERANCE_COLUMN, \
                   GOLDEN_INTENT_COLUMN, TEST_OUT_FILENAME, WORKSPACE_ID_TAG, \
                   WCS_VERSION, UTF_8, INTENT_JUDGE_COLUMN, BOOL_MAP, \
-                  DEFAULT_TEST_RATE, POPULATION_WEIGHT_MODE, \
+                  DEFAULT_TEST_RATE, POPULATION_WEIGHT_MODE, DEFAULT_TEMP_DIR, FOLD_NUM_DEFAULT, \
                   DEFAULT_CONF_THRES, WCS_USERNAME_ITEM, WCS_PASSWORD_ITEM, WCS_IAM_APIKEY_ITEM, WCS_BASEURL_ITEM, \
                   WCS_CREDS_SECTION, CREATE_TEST_TRAIN_FOLDS_PATH, \
                   TRAIN_CONVERSATION_PATH, TEST_CONVERSATION_PATH, \
@@ -46,6 +46,7 @@ ENTITY_FILE_ITEM = 'entity_train_file'
 TEST_FILE_ITEM = 'test_input_file'
 TEST_OUT_PATH_ITEM = 'test_output_path'
 TEMP_DIR_ITEM = 'temporary_file_directory'
+OUT_DIR_ITEM = 'output_directory'
 FIGURE_PATH_ITEM = 'out_figure_path'
 FOLD_NUM_ITEM = 'fold_num'
 DO_KEEP_WORKSPACE_ITEM = 'keep_workspace_after_test'
@@ -62,7 +63,6 @@ MAX_TEST_RATE = DEFAULT_TEST_RATE
 
 KFOLD_UNION_FILE = 'kfold-test-out-union.csv'
 
-
 def validate_config(fields, section):
     for field in fields:
         if field not in section:
@@ -77,7 +77,7 @@ def list_workspaces(username, password, iam_apikey, url):
     return c.list_workspaces()
 
 
-def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
+def kfold(fold_num, out_dir, intent_train_file, workspace_base_file,
           figure_path, keep_workspace, username, password, iam_apikey, url, weight_mode,
           conf_thres, partial_credit_table):
     FOLD_TRAIN = 'fold_train'
@@ -90,7 +90,7 @@ def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
     print('{}={}'.format(INTENT_FILE_ITEM, intent_train_file))
     print('{}={}'.format(WORKSPACE_BASE_ITEM, workspace_base_file))
     print('{}={}'.format(FIGURE_PATH_ITEM, figure_path))
-    print('{}={}'.format(TEMP_DIR_ITEM, temp_dir))
+    print('{}={}'.format(OUT_DIR_ITEM, out_dir))
     print('{}={}'.format(FOLD_NUM_ITEM, fold_num))
     print('{}={}'.format(DO_KEEP_WORKSPACE_ITEM, BOOL_MAP[keep_workspace]))
     print('{}={}'.format(WEIGHT_MODE_ITEM, weight_mode))
@@ -99,7 +99,7 @@ def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
     print('{}={}'.format(WCS_BASEURL_ITEM, url))
     print('{}={}'.format(PARTIAL_CREDIT_TABLE_ITEM, partial_credit_table))
 
-    working_dir = os.path.join(temp_dir, KFOLD)
+    working_dir = os.path.join(out_dir, KFOLD)
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
 
@@ -196,11 +196,13 @@ def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
 
 
         # Union test out
+        kfold_result_file = os.path.join(out_dir, KFOLD_UNION_FILE)
         pd.concat([pd.read_csv(file, quoting=csv.QUOTE_ALL, encoding=UTF_8,
                                keep_default_na=False)
                    for file in test_out_files]) \
-          .to_csv(os.path.join(working_dir, KFOLD_UNION_FILE),
+          .to_csv(kfold_result_file,
                   encoding='utf-8', quoting=csv.QUOTE_ALL, index=False)
+        print("Wrote k-fold result file to {}".format(kfold_result_file))
 
         classfier_names = ['Fold {}'.format(idx) for idx in range(fold_num)]
 
@@ -210,29 +212,21 @@ def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
                      '--tau', conf_thres, '-n'] + \
             classfier_names + ['-i'] + test_out_files
 
-        if subprocess.run(plot_args).returncode == 0:
-            print('Generated precision curves for {} folds'.format(
-                str(fold_num)))
-        else:
+        if subprocess.run(plot_args).returncode != 0:
             raise RuntimeError('Failure in plotting curves')
 
-        kfold_result_file = os.path.join(working_dir, KFOLD_UNION_FILE)
         kfold_result_file_base = kfold_result_file[:-4]
         metrics_args = [sys.executable, INTENT_METRICS_PATH,
                      '-i', kfold_result_file,
                      '-o', kfold_result_file_base+".metrics.csv",
                      '--partial_credit_on', str(partial_credit_table is not None)]
-        if subprocess.run(metrics_args).returncode == 0:
-            print('Generated intent metrics')
-        else:
+        if subprocess.run(metrics_args).returncode != 0:
             raise RuntimeError('Failure in generating intent metrics')
 
-        confusion_args = [sys.executable, CONFUSION_MATRIX_PATH, 
+        confusion_args = [sys.executable, CONFUSION_MATRIX_PATH,
                           '-i', kfold_result_file,
                           '-o', kfold_result_file_base+".confusion_args.csv"]
-        if subprocess.run(confusion_args).returncode == 0:
-            print('Generated confusion matrix')
-        else:
+        if subprocess.run(confusion_args).returncode != 0:
             raise RuntimeError('Failure in generating confusion matrix')
 
     finally:
@@ -247,7 +241,7 @@ def kfold(fold_num, temp_dir, intent_train_file, workspace_base_file,
             delete_workspaces(username, password, iam_apikey, url, workspace_ids)
 
 
-def blind(temp_dir, intent_train_file, workspace_base_file, figure_path,
+def blind(out_dir, intent_train_file, workspace_base_file, figure_path,
           test_out_path, test_input_file, previous_blind_out, keep_workspace,
           username, password, iam_apikey, url, weight_mode, conf_thres, partial_credit_table, figure_title):
     print('Begin {} with following details:'.format(BLIND_TEST.upper()))
@@ -257,7 +251,7 @@ def blind(temp_dir, intent_train_file, workspace_base_file, figure_path,
     print('{}={}'.format(PREVIOUS_BLIND_OUT_ITEM, previous_blind_out))
     print('{}={}'.format(FIGURE_PATH_ITEM, figure_path))
     print('{}={}'.format(TEST_OUT_PATH_ITEM, test_out_path))
-    print('{}={}'.format(TEMP_DIR_ITEM, temp_dir))
+    print('{}={}'.format(OUT_DIR_ITEM, out_dir))
     print('{}={}'.format(DO_KEEP_WORKSPACE_ITEM, BOOL_MAP[keep_workspace]))
     print('{}={}'.format(WEIGHT_MODE_ITEM, weight_mode))
     print('{}={}'.format(CONF_THRES_ITEM, conf_thres))
@@ -282,7 +276,7 @@ def blind(temp_dir, intent_train_file, workspace_base_file, figure_path,
         test_out_files.append(previous_blind_out)
         classfier_names.append('Old Classifier')
 
-    working_dir = os.path.join(temp_dir, BLIND_TEST)
+    working_dir = os.path.join(out_dir, BLIND_TEST)
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
 
@@ -321,9 +315,7 @@ def blind(temp_dir, intent_train_file, workspace_base_file, figure_path,
                            '-t', figure_title, '-w', weight_mode, '--tau',
                            conf_thres, '-o', figure_path,
                            '-n'] + classfier_names +
-                          ['-i'] + test_out_files).returncode == 0:
-            print('Generated precision curves for blind set')
-        else:
+                          ['-i'] + test_out_files).returncode != 0:
             raise RuntimeError('Failure in plotting curves')
 
         blind_result_file = test_out_path
@@ -332,31 +324,27 @@ def blind(temp_dir, intent_train_file, workspace_base_file, figure_path,
                         '-i', blind_result_file,
                         '-o', blind_result_file_base+"_metrics.csv",
                         '--partial_credit_on', str(partial_credit_table is not None)]
-        if subprocess.run(metrics_args).returncode == 0:
-            print('Generated intent metrics')
-        else:
+        if subprocess.run(metrics_args).returncode != 0:
             raise RuntimeError('Failure in generating intent metrics')
 
         confusion_args = [sys.executable, CONFUSION_MATRIX_PATH,
                           '-i', blind_result_file,
                           '-o', blind_result_file_base+"_confusion.csv"]
-        if subprocess.run(confusion_args).returncode == 0:
-            print('Generated confusion matrix')
-        else:
+        if subprocess.run(confusion_args).returncode != 0:
             raise RuntimeError('Failure in generating confusion matrix')
     finally:
         if not keep_workspace:
             delete_workspaces(username, password, iam_apikey, url, [workspace_id])
 
 
-def test(temp_dir, intent_train_file, workspace_base_file, test_out_path,
+def test(out_dir, intent_train_file, workspace_base_file, test_out_path,
          test_input_file, keep_workspace, username, password, iam_apikey, url):
     print('Begin {} with following details:'.format(STANDARD_TEST.upper()))
     print('{}={}'.format(INTENT_FILE_ITEM, intent_train_file))
     print('{}={}'.format(WORKSPACE_BASE_ITEM, workspace_base_file))
     print('{}={}'.format(TEST_FILE_ITEM, test_input_file))
     print('{}={}'.format(TEST_OUT_PATH_ITEM, test_out_path))
-    print('{}={}'.format(TEMP_DIR_ITEM, temp_dir))
+    print('{}={}'.format(OUT_DIR_ITEM, out_dir))
     print('{}={}'.format(DO_KEEP_WORKSPACE_ITEM, BOOL_MAP[keep_workspace]))
     print('{}={}'.format(WCS_USERNAME_ITEM, username))
     print('{}={}'.format(WCS_BASEURL_ITEM, url))
@@ -373,7 +361,7 @@ def test(temp_dir, intent_train_file, workspace_base_file, test_out_path,
             raise ValueError('Test input has unknown utterance column')
 
     # Run standard test
-    working_dir = os.path.join(temp_dir, STANDARD_TEST)
+    working_dir = os.path.join(out_dir, STANDARD_TEST)
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
 
@@ -441,24 +429,25 @@ def func(args):
 
     default_section = config[DEFAULT_SECTION]
 
-    # Main params validation
-    validate_config([MODE_ITEM, TEMP_DIR_ITEM, WORKSPACE_ID_ITEM],
-                    default_section)
+    # Main params validation - make sure required parameters are passed
+    validate_config([MODE_ITEM, WORKSPACE_ID_ITEM], default_section)
 
-    temp_dir = default_section[TEMP_DIR_ITEM]
+    #TEMP_DIR_ITEM is legacy configuration variable, subsumed by OUT_DIR_ITEM
+    temp_dir = default_section.get(TEMP_DIR_ITEM, DEFAULT_TEMP_DIR)
+    out_dir  = default_section.get(OUT_DIR_ITEM, temp_dir)
 
     # Prepare folds
     if subprocess.run([sys.executable, WORKSPACE_PARSER_PATH,
                        '-i', default_section[WORKSPACE_ID_ITEM],
-                       '-o', temp_dir,
+                       '-o', out_dir,
                        '-u', username, '-p', password, '-a', iam_apikey, '-l', url],
                       stdout=subprocess.PIPE).returncode == 0:
         print('Parsed workspace')
     else:
         raise RuntimeError('Failure in parsing workspace')
 
-    intent_train_file = os.path.join(temp_dir, 'intent-train.csv')
-    workspace_base_file = os.path.join(temp_dir, WORKSPACE_BASE_FILENAME)
+    intent_train_file = os.path.join(out_dir, 'intent-train.csv')
+    workspace_base_file = os.path.join(out_dir, WORKSPACE_BASE_FILENAME)
 
     # Convert yes/no to boolean
     keep_workspace = False
@@ -481,55 +470,48 @@ def func(args):
             print(e)
     print('Maximum testing rate: {}/cycle'.format(MAX_TEST_RATE))
 
-    weight_mode = POPULATION_WEIGHT_MODE
-    if WEIGHT_MODE_ITEM in default_section:
-        weight_mode = default_section[WEIGHT_MODE_ITEM]
-
-    conf_thres_str = str(DEFAULT_CONF_THRES)
-    if CONF_THRES_ITEM in default_section:
-        conf_thres_str = default_section[CONF_THRES_ITEM]
-
-    partial_credit_table = None
-    if PARTIAL_CREDIT_TABLE_ITEM in default_section:
-        partial_credit_table = default_section[PARTIAL_CREDIT_TABLE_ITEM]
+    weight_mode          = default_section.get(WEIGHT_MODE_ITEM, POPULATION_WEIGHT_MODE).lower()
+    conf_thres_str       = default_section.get(CONF_THRES_ITEM, str(DEFAULT_CONF_THRES))
+    partial_credit_table = default_section.get(PARTIAL_CREDIT_TABLE_ITEM, None)
+    figure_path          = default_section.get(FIGURE_PATH_ITEM, out_dir + "/" + mode + ".jpg")
 
     if KFOLD == mode:
-        # Field validation for kfold
-        validate_config([FOLD_NUM_ITEM, FIGURE_PATH_ITEM], default_section)
+        fold_num = default_section.get(FOLD_NUM_ITEM, FOLD_NUM_DEFAULT)
 
-        kfold(fold_num=int(default_section[FOLD_NUM_ITEM]),
-              temp_dir=temp_dir,
+        kfold(fold_num=int(fold_num),
+              out_dir=out_dir,
               intent_train_file=intent_train_file,
               workspace_base_file=workspace_base_file,
-              figure_path=default_section[FIGURE_PATH_ITEM],
+              figure_path=figure_path,
               keep_workspace=keep_workspace,
               username=username, password=password, iam_apikey=iam_apikey, url=url,
               weight_mode=weight_mode, conf_thres=conf_thres_str,
               partial_credit_table=partial_credit_table)
     else:
-        validate_config([TEST_FILE_ITEM, TEST_OUT_PATH_ITEM], default_section)
+        test_input_file = default_section.get(TEST_FILE_ITEM, out_dir + "/input.csv")
+        test_out_path   = default_section.get(TEST_OUT_PATH_ITEM, out_dir + "/" + mode + "-out.csv")
 
         if BLIND_TEST == mode:
-            previous_blind_out = default_section.get(
-                PREVIOUS_BLIND_OUT_ITEM, None)
-            blind(temp_dir=temp_dir,
+            previous_blind_out = default_section.get(PREVIOUS_BLIND_OUT_ITEM, None)
+            blind_figure_title = default_section.get(BLIND_FIGURE_TITLE,'Blind Test Results')
+            blind(out_dir=out_dir,
                   intent_train_file=intent_train_file,
                   workspace_base_file=workspace_base_file,
-                  test_input_file=default_section[TEST_FILE_ITEM],
-                  figure_path=default_section[FIGURE_PATH_ITEM],
-                  test_out_path=default_section[TEST_OUT_PATH_ITEM],
+                  test_input_file=test_input_file,
+                  figure_path=figure_path,
+                  test_out_path=test_out_path,
                   previous_blind_out=previous_blind_out,
                   keep_workspace=keep_workspace,
                   username=username, password=password, iam_apikey=iam_apikey, url=url,
                   weight_mode=weight_mode, conf_thres=conf_thres_str,
                   partial_credit_table=partial_credit_table,
-                  figure_title=default_section[BLIND_FIGURE_TITLE])
+                  figure_title=blind_figure_title)
         elif STANDARD_TEST == mode:
-            test(temp_dir=temp_dir,
+            test(out_dir=out_dir,
                  intent_train_file=intent_train_file,
                  workspace_base_file=workspace_base_file,
-                 test_input_file=default_section[TEST_FILE_ITEM],
-                 test_out_path=default_section[TEST_OUT_PATH_ITEM],
+                 test_input_file=test_input_file,
+                 test_out_path=test_out_path,
                  keep_workspace=keep_workspace,
                  username=username,
                  password=password,

--- a/tests/test_workspaceParser.py
+++ b/tests/test_workspaceParser.py
@@ -26,7 +26,7 @@ sys.path.insert(0, tool_base)
 import workspaceParser
 from utils import WCS_CREDS_SECTION, WCS_USERNAME_ITEM, SPEC_FILENAME, \
                   WCS_PASSWORD_ITEM, TRAIN_CONVERSATION_PATH, \
-                  delete_workspaces, WORKSPACE_ID_TAG
+                  delete_workspaces, WORKSPACE_ID_TAG, DEFAULT_WA_VERSION
 
 
 class WorkspaceParserTestCase(CommandLineTestCase):
@@ -57,7 +57,7 @@ class WorkspaceParserTestCase(CommandLineTestCase):
         password = config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i', intent_path,
-                '-e', entity_path, '-u', username, '-p', password]
+                '-e', entity_path, '-u', username, '-p', password, '-v', DEFAULT_WA_VERSION]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
         # Train a new instance in order to pull the workspace detail

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -74,6 +74,7 @@ TIME_TO_WAIT = 600
 BOOL_MAP = {True: 'yes', False: 'no'}
 DEFAULT_TEST_RATE = 100
 DEFAULT_CONF_THRES = 0.2
+DEFAULT_TEMP_DIR = "./data"
 
 POPULATION_WEIGHT_MODE = 'population'
 EQUAL_WEIGHT_MODE = 'equal'

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -43,6 +43,7 @@ WCS_PASSWORD_ITEM = 'password'
 WCS_IAM_APIKEY_ITEM = 'iam_apikey'
 WCS_BASEURL_ITEM = 'url'
 WCS_CREDS_SECTION = 'ASSISTANT CREDENTIALS'
+WA_API_VERSION_ITEM = 'version'
 
 SPEC_FILENAME = 'workspace.json'
 WORKSPACE_BASE_FILENAME = 'workspace_base.json'
@@ -68,7 +69,7 @@ BLIND_TEST = 'blind'
 STANDARD_TEST = 'test'
 
 FOLD_NUM_DEFAULT = 5
-WCS_VERSION = '2018-07-10'
+DEFAULT_WA_VERSION = '2019-02-28'
 WORKSPACE_ID_TAG = 'workspace_id'
 TIME_TO_WAIT = 600
 BOOL_MAP = {True: 'yes', False: 'no'}
@@ -118,11 +119,11 @@ def unmarshall_entity(entities_str):
     return entities
 
 
-def delete_workspaces(username, password, iam_apikey, url, workspace_ids):
+def delete_workspaces(username, password, iam_apikey, url, version, workspace_ids):
     """ Delete workspaces
     """
     c = AssistantV1(username=username, password=password, iam_apikey=iam_apikey,
-                    version=WCS_VERSION, url=url)
+                    version=version, url=url)
     for workspace_id in workspace_ids:
         c.delete_workspace(workspace_id=workspace_id)
     print('Cleaned up workspaces')

--- a/utils/createPrecisionCurve.py
+++ b/utils/createPrecisionCurve.py
@@ -210,6 +210,8 @@ def func(args):
     # Save figure as file
     plt.savefig(args.outfile)
 
+    print("Wrote precision curve to {}".format(args.outfile))
+
 
 def create_parser():
     parser = ArgumentParser(description="Draw precision curves on a single canvas \

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -28,7 +28,7 @@ from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \
     DETECTED_ENTITY_COLUMN, DIALOG_RESPONSE_COLUMN, \
     marshall_entity, save_dataframe_as_csv, INTENT_JUDGE_COLUMN, \
-    TEST_OUT_FILENAME, BOOL_MAP, WCS_VERSION, BASE_URL, \
+    TEST_OUT_FILENAME, BOOL_MAP, BASE_URL, DEFAULT_WA_VERSION, \
     parse_partial_credit_table, SCORE_COLUMN
 
 test_out_header = [PREDICTED_INTENT_COLUMN, CONFIDENCE_COLUMN,
@@ -67,13 +67,13 @@ async def post(session, json, url, sem):
 
 
 async def fill_df(utterance, row_idx, out_df, workspace_id, wa_username,
-                  wa_password, sem, baseUrl):
+                  wa_password, sem, baseUrl, version):
     """ Send utterance to Assistant and save response to dataframe
     """
     async with aiohttp.ClientSession(
             auth=aiohttp.BasicAuth(wa_username, wa_password)) as session:
         MSG_ENDPOINT = baseUrl + '/v1/workspaces/{}/message?version={}'
-        url = MSG_ENDPOINT.format(workspace_id, WCS_VERSION)
+        url = MSG_ENDPOINT.format(workspace_id, version)
 
         # Replace newline chars before sending to WA
         utterance = utterance.replace('\n', ' ')
@@ -139,7 +139,7 @@ def func(args):
 
     tasks = (fill_df(out_df.loc[row_idx, test_column],
                      row_idx, out_df, args.workspace_id,
-                     args.username, args.password, sem, args.url)
+                     args.username, args.password, sem, args.url, args.version)
              for row_idx in range(out_df.shape[0]))
     loop.run_until_complete(asyncio.gather(*tasks))
 
@@ -204,6 +204,8 @@ def create_parser():
                         help='Maximum number of requests per second')
     parser.add_argument('-c', '--partial_credit_table', type=str,
                         help='Partial credit table')
+    parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
+                        help='Watson Assistant API version in YYYY-MM-DD form')
     return parser
 
 

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -172,6 +172,7 @@ def func(args):
                     credit_tables[golden_intent][predict_intent]
 
     save_dataframe_as_csv(df=out_df, file=args.outfile)
+    print("Wrote standard test result file to {}".format(args.outfile))
 
 
 def create_parser():

--- a/utils/trainConversation.py
+++ b/utils/trainConversation.py
@@ -28,7 +28,7 @@ import pandas as pd
 from argparse import ArgumentParser
 from watson_developer_cloud import AssistantV1
 
-from __init__ import UTF_8, WCS_VERSION, \
+from __init__ import UTF_8, DEFAULT_WA_VERSION,\
                   UTTERANCE_COLUMN, INTENT_COLUMN, \
                   TIME_TO_WAIT, WORKSPACE_ID_TAG
 
@@ -162,7 +162,7 @@ def func(args):
                     for _, row in entity_df.iterrows()]
 
     conv = AssistantV1(iam_apikey=args.iam_apikey, username=args.username, password=args.password,
-                       version=WCS_VERSION, url=args.url)
+                       version=args.version, url=args.url)
 
     if args.workspace_name is not None:
         workspace_name = args.workspace_name
@@ -223,6 +223,8 @@ def create_parser():
                         help='Assistant service password')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/assistant/api',
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
+    parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
+                        help='Watson Assistant API version in YYYY-MM-DD form')
 
     return parser
 

--- a/utils/workspaceParser.py
+++ b/utils/workspaceParser.py
@@ -22,7 +22,7 @@ import json
 import os.path
 from argparse import ArgumentParser
 from watson_developer_cloud import AssistantV1
-from __init__ import WCS_VERSION, TRAIN_INTENT_FILENAME, \
+from __init__ import TRAIN_INTENT_FILENAME, DEFAULT_WA_VERSION, \
                      TRAIN_ENTITY_FILENAME, WORKSPACE_BASE_FILENAME, UTF_8
 
 
@@ -30,7 +30,7 @@ def func(args):
     workspace = None
     if not os.path.isfile(args.input):
         conv = AssistantV1(username=args.username, password=args.password, iam_apikey=args.iam_apikey,
-                           version=WCS_VERSION, url=args.url)
+                           version=args.version, url=args.url)
         raw_workspace = conv.get_workspace(workspace_id=args.input, export=True)
         try:
            #V2 API syntax
@@ -96,6 +96,8 @@ def create_parser():
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-o', '--outdir', type=str, help='Output directory',
                         default=os.getcwd())
+    parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
+                        help='Watson Assistant API version in YYYY-MM-DD form')
     return parser
 
 


### PR DESCRIPTION
Solves both #81 and #86 as they were easily coded and tested together.

The commits for each issue are kept separate for easier reviewing.

Almost all parameters in the "default" section are now made optional except for mode and workspace_id.  config.ini.sample shows additional legal parameters and their default values.
Most critically, the required values are all at the top and the optional values are below, there are no optional values 'above' required values thus making the file a bit easier to understand.

Blind/test "input" file is defaulted to `data/input.csv`, users are allowed and encouraged to provide alternate names.

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>