### PR TITLE
Document initial setup of tool and suggest python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ and positive predictive value rates, and a confustion matrix.
 - Able to resume from where it stops using modularized scripts.
 
 ## Prerequisite
-- *nix OS (Recommend)
 - Python 3.6.4 +
+- Mac users: you may need to initialize Python's SSL certificate store by running `Install Certificates.command` found in `/Applications/Python`.  See more [here](https://github.com/cognitive-catalyst/WA-Testing-Tool/issues/38)
+
 
 ## Quick Start
-1. Install dependencies `pip install -r requirements.txt`
+1. Install dependencies `pip3 install -r requirements.txt`
 2. Set up parameters properly in `config.ini`. Use `config.ini.sample` to bootstrap your configuration.
-3. Run the process. `python run.py -c <path to config.ini>`
+3. Run the process. `python3 run.py -c <path to config.ini>`
 
 ## Input Files
 `config.ini` - Configuration file for `run.py`.
@@ -69,10 +70,12 @@ There are a variety of ways to use this tool.  Primarily you will execute a k-fo
 [Extract utterances leading to a dialog node](extract_utterances/README.md)
 
 ## Caveats and Troubleshooting
-Due to different coverage among service plans, user may need to adjust `max_test_rate` accordingly to avoid network connection error.
+1. Due to different coverage among service plans, user may need to adjust `max_test_rate` accordingly to avoid network connection error.
 
-Users on Lite plans are only able to create 5 workspaces.  They should set `fold_num=3` on their k-fold configuration file.
+2. Users on Lite plans are only able to create 5 workspaces.  They should set `fold_num=3` on their k-fold configuration file.
 
-In case of interrupted execution, the tool may not be able to clean up the workspaces it creates.  In this case you will need to manually delete the extra workspaces.
+3. In case of interrupted execution, the tool may not be able to clean up the workspaces it creates.  In this case you will need to manually delete the extra workspaces.
 
-Workspace ID is *not* the Skill ID.  In the Watson Assistant user interface, the Workspace ID can be found on the Skills tab, clicking the three dots (top-right of skill), and choosing View API Details.
+4. Workspace ID is *not* the Skill ID.  In the Watson Assistant user interface, the Workspace ID can be found on the Skills tab, clicking the three dots (top-right of skill), and choosing View API Details.
+
+5. SSL: [CERTIFICATE_VERIFY_FAILED] on Mac means you may need to initialize Python's SSL certificate store by running `Install Certificates.command` found in `/Applications/Python`.  See more [here](https://github.com/cognitive-catalyst/WA-Testing-Tool/issues/38)

--- a/dialog_test/README.md
+++ b/dialog_test/README.md
@@ -11,12 +11,12 @@ This is done with the `export` command on Mac/Linux shell or `SET` in Windows
 
 Run a sample test as follows:
 ```
-python flowtest.py tests/Customer_Care_Test.tsv
+python3 flowtest.py tests/Customer_Care_Test.tsv
 ```
 
 Run all tests in a directory (and it's subdirectories) as follows:
 ```
-python flowtest.py tests
+python3 flowtest.py tests
 ```
 
 Check the `results` folder for test output.  If any MATCH column has a 'FALSE' value, the test has failed.

--- a/examples/confusion-matrix.md
+++ b/examples/confusion-matrix.md
@@ -8,7 +8,7 @@ There are two starting possibilities:
 
 1) The user has run existing [k-folds](kfold.md) or [blind](blind.md) test which creates a summary .csv file
 
-2) The user has a separate analysis which creates a .csv file with "golden" and "predicted" columns 
+2) The user has a separate analysis which creates a .csv file with "golden" and "predicted" columns
 
 User executes `confusionmatrix.py` providing an input filename and output filename.  If using workflow 2, the user provides the names of the golden and predicted column header names with `-g` and `-t` respectively.
 The summary is written to the output filename.
@@ -18,10 +18,10 @@ User must have an input .csv file containing at least two column headers represe
 
 ## Invocation
 Workflow #1
-Assuming input file at `data/test-out.csv` created by other tools in this repository and writing to `test-out-matrix.csv'. 
+Assuming input file at `data/test-out.csv` created by other tools in this repository and writing to `test-out-matrix.csv'.
 
 ```
-python utils/confusionmatrix.py -i data/test-out.csv -o data/test-out-matrix.csv
+python3 utils/confusionmatrix.py -i data/test-out.csv -o data/test-out-matrix.csv
 ```
 
 Workflow #2
@@ -41,7 +41,7 @@ Assuming input file at `data/golden_vs_predicted.csv` and writing to `data/golde
 
 Invoke via:
 ```
-python utils/confusionmatrix.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-matrix.csv -t "predicted" -g "golden"
+python3 utils/confusionmatrix.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-matrix.csv -t "predicted" -g "golden"
 ```
 
 ## Sample output

--- a/examples/intent-description.md
+++ b/examples/intent-description.md
@@ -25,7 +25,7 @@ positional arguments:
 
 ## Local Watson Assistant Workspace File
 ```console
-$ python get_intent_description.py local path/to/workspace.json
+$ python3 get_intent_description.py local path/to/workspace.json
 ```
 
 ```
@@ -42,7 +42,7 @@ optional arguments:
 
 ## Remote Watson Assistant Workspace
 ```console
-$ python get_intent_description.py remote -u <wa-username> -p <wa-password> -w <wa-workspace-id>
+$ python3 get_intent_description.py remote -u <wa-username> -p <wa-password> -w <wa-workspace-id>
 ```
 
 

--- a/examples/intent-metrics.md
+++ b/examples/intent-metrics.md
@@ -21,7 +21,7 @@ Workflow #1
 Assuming input file at `data/test-out.csv` created by other tools in this repository and writing to `test-out-metrics.csv'.
 
 ```
-python utils/intentmetrics.py -i data/test-out.csv -o data/test-out-metrics.csv
+python3 utils/intentmetrics.py -i data/test-out.csv -o data/test-out-metrics.csv
 ```
 
 Workflow #2
@@ -41,7 +41,7 @@ Assuming input file at `data/golden_vs_predicted.csv` and writing to `data/golde
 
 Invoke via:
 ```
-python utils/intentmetrics.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-metrics.csv -t "predicted" -g "golden"
+python3 utils/intentmetrics.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-metrics.csv -t "predicted" -g "golden"
 ```
 
 ## Sample output

--- a/examples/long-tail-scoring.md
+++ b/examples/long-tail-scoring.md
@@ -23,7 +23,7 @@ Workflow #1
 Assuming input file at `data/blind-out.csv` created by other tools in this repository and writing to `blind-out-metrics.csv'.
 
 ```
-python utils/longtailscoring.py -i data/blind-out.csv -o data/blind-out-metrics.csv
+python3 utils/longtailscoring.py -i data/blind-out.csv -o data/blind-out-metrics.csv
 ```
 
 Workflow #2
@@ -43,7 +43,7 @@ Assuming input file at `data/golden_vs_predicted.csv` and writing to `data/golde
 
 Invoke via:
 ```
-python utils/longtailscoring.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-metrics.csv -t "predicted" -g "golden" -c "conf" -l 0.5 -n "out_of_scope"
+python3 utils/longtailscoring.py -i data/golden_vs_predicted.csv -o data/golden_vs_predicted-metrics.csv -t "predicted" -g "golden" -c "conf" -l 0.5 -n "out_of_scope"
 ```
 
 ## Sample output

--- a/extract_utterances/README.md
+++ b/extract_utterances/README.md
@@ -26,11 +26,11 @@ You may optionally provide
 Example execution:
 
 ```
-python getUtteranceBeforeNode.py -n node_1_1234567890123 -a 1111222233334444555566667777888899990000 -w 11111111-2222-3333-4444-555566667777 -l https://gateway-wdc.watsonplatform.net/assistant/api -c all -o output.tsv
+python3 getUtteranceBeforeNode.py -n node_1_1234567890123 -a 1111222233334444555566667777888899990000 -w 11111111-2222-3333-4444-555566667777 -l https://gateway-wdc.watsonplatform.net/assistant/api -c all -o output.tsv
 ```
 
 You can print the help using the following command:
 
 ```
-python getUtteranceBeforeNode.py -h
+python3 getUtteranceBeforeNode.py -h
 ```

--- a/validate_workspace/README.md
+++ b/validate_workspace/README.md
@@ -20,13 +20,13 @@ A online connection to the workspace is referenced with "`-o` `--username` your_
 To validate a workspace against an SOE contract, invoke with `-s`.  You can optionally specify the legal "route" values with `--soe_route`
 
 ```
-python validateWS.py -f your_workspace_file.json -s --soe_route "TTS,OPT_OUT,UI,SOE,API,None"
+python3 validateWS.py -f your_workspace_file.json -s --soe_route "TTS,OPT_OUT,UI,SOE,API,None"
 ```
 
 To validate a workspace against IBM Voice Gateway syntax, invoke with `-g`.  You can optionally specify the expected voice gateway commands that should be present on any playback nodes with `--voice_gateway_commands`
 
 ```
-python validateWS.py -f your_workspace_file.json -g --voice_gateway_commands "vgwActSetSTTConfig,vgwActPlayText"
+python3 validateWS.py -f your_workspace_file.json -g --voice_gateway_commands "vgwActSetSTTConfig,vgwActPlayText"
 ```
 
 Note that you can simultaneously validate against SOE contract and IBM Voice Gateway syntax by specifying both `-s` and `-g` options.


### PR DESCRIPTION
Addresses #90 

Improves documentation for initial installation by pointing out need for Mac users to initialize SSL store.
Also clarifies python3 as supported runtime environment in the example commands.

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>