### PR TITLE
PNG default & JPG support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ aiohttp>=3.4
 configparser
 squarify>=0.3.0
 ibm-watson==3.4.0
+pillow==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ aiohttp>=3.4
 configparser
 squarify>=0.3.0
 ibm-watson==3.4.0
+seaborn>=0.9.0
 pillow==6.1.0
+

--- a/run.py
+++ b/run.py
@@ -477,7 +477,7 @@ def func(args):
     weight_mode          = default_section.get(WEIGHT_MODE_ITEM, POPULATION_WEIGHT_MODE).lower()
     conf_thres_str       = default_section.get(CONF_THRES_ITEM, str(DEFAULT_CONF_THRES))
     partial_credit_table = default_section.get(PARTIAL_CREDIT_TABLE_ITEM, None)
-    figure_path          = default_section.get(FIGURE_PATH_ITEM, out_dir + "/" + mode + ".jpg")
+    figure_path          = default_section.get(FIGURE_PATH_ITEM, out_dir + "/" + mode + ".png")
 
     if KFOLD == mode:
         fold_num = default_section.get(FOLD_NUM_ITEM, FOLD_NUM_DEFAULT)


### PR DESCRIPTION
Defaulted to PNG output & updated requirements.txt to support JPG (added pillow lib)

https://github.com/cognitive-catalyst/WA-Testing-Tool/issues/91

DCO 1.1 Signed-off-by: Andrew Pang <apang@us.ibm.com>