### PR TITLE
Remove username/password from code and documentation

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,10 +1,6 @@
 [ASSISTANT CREDENTIALS]
 ; Regardless of mode you must specify a WA environment to test the classification against.
-; If your WA environment provides username and password, configure them and leave iam_apikey empty
-; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
 ; Update the url for the WA API to match your specific WA region
-username =
-password =
 iam_apikey =
 url = https://gateway.watsonplatform.net/assistant/api
 

--- a/dialog_test/README.md
+++ b/dialog_test/README.md
@@ -6,7 +6,7 @@ Prerequisites:
 * Watson Developer Cloud SDK (1.x or 2.x)
 
 ## Running the tests
-You will need to set three environment variables: ASSISTANT_USERNAME, ASSISTANT_PASSWORD, WORKSPACE_ID and ASSISTANT_URL.  The WORKSPACE_ID should be the first workspace the test executes against.  
+You will need to set three environment variables: ASSISTANT_PASSWORD, WORKSPACE_ID and ASSISTANT_URL.  The WORKSPACE_ID should be the first workspace the test executes against.  The ASSISTANT_PASSWORD is your IAM apikey.
 This is done with the `export` command on Mac/Linux shell or `SET` in Windows
 
 Run a sample test as follows:

--- a/dialog_test/flowtest.py
+++ b/dialog_test/flowtest.py
@@ -7,7 +7,6 @@ import pandas as pd
 DATA_FOLDER='tests'
 OUTPUT_FOLDER='results'
 url_default="https://gateway.watsonplatform.net/assistant/api"
-USERNAME=os.environ["ASSISTANT_USERNAME"]
 PASSWORD=os.environ["ASSISTANT_PASSWORD"]
 WA_URL=os.environ.get("ASSISTANT_URL", url_default)
 workspace_id=os.environ["WORKSPACE_ID"]
@@ -24,12 +23,8 @@ def validateArguments():
         print("ERROR: Required arguments: test filename (tab-separated file)")
         exit(-1)
 
-    if len(USERNAME) < 5:
-        print ('No valid ASSISTANT_USERNAME specified in environment')
-        sys.exit(-2)
-
     if len(PASSWORD) < 5:
-        print ('No valid ASSISTANT_PASSWORD specified in environment')
+        print ('No valid ASSISTANT_PASSWORD specified in environment (password is your IAM apikey)')
         sys.exit(-3)
 
     if len(workspace_id) < 5:
@@ -79,7 +74,7 @@ def processFile(flowfile:str, watsonSDKVersion:str):
     #print(flow)
     #print()
 
-    ft = flowtest_v1.FlowTestV1(username=USERNAME, password=PASSWORD, version=conversation_version, url=url_default)
+    ft = flowtest_v1.FlowTestV1(password=PASSWORD, version=conversation_version, url=url_default)
 
     # print('Creating blank template: ')
     # blank_flow = ft.createBlankTemplate()

--- a/examples/blind.md
+++ b/examples/blind.md
@@ -12,10 +12,6 @@ Further, reports are generated for an [intent metrics summary](intent-metrics.md
 
 ```
 [ASSISTANT CREDENTIALS]
-; If your WA environment provides username and password, configure them and leave iam_apikey empty
-; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
-username = <wa username>
-password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
 version=2019-02-28

--- a/examples/intent-description.md
+++ b/examples/intent-description.md
@@ -42,14 +42,13 @@ optional arguments:
 
 ## Remote Watson Assistant Workspace
 ```console
-$ python3 get_intent_description.py remote -u <wa-username> -p <wa-password> -w <wa-workspace-id>
+$ python3 get_intent_description.py remote -a <wa-iam-apikey> -w <wa-workspace-id>
 ```
 
 
 ```
-usage: get_intent_description.py remote [-h] [--output OUTPUT] --user USER
-                                        --password PASSWORD --workspace_id
-                                        WORKSPACE_ID
+usage: get_intent_description.py remote [-h] [--output OUTPUT] --iam_apikey APIKEY
+                                        --workspace_id WORKSPACE_ID
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -57,9 +56,7 @@ optional arguments:
                         Output file (default: intent_desc.csv)
 
 required arguments:
-  --user USER, -u USER  Watson Assistant Username (default: None)
-  --password PASSWORD, -p PASSWORD
-                        Watson Assistant Password (default: None)
+  --iam_apikey APIKEY, -a apikey  Watson Assistant IAM API key (default: None)
   --workspace_id WORKSPACE_ID, -w WORKSPACE_ID
                         Watson Assistant Workspace ID (default: None)
 

--- a/examples/kfold.md
+++ b/examples/kfold.md
@@ -16,10 +16,6 @@ User's workspace must allow to create 5 more workspaces. For 'lite' plans, use 3
 
 ```
 [ASSISTANT CREDENTIALS]
-; If your WA environment provides username and password, configure them and leave iam_apikey empty
-; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
-username = <wa username>
-password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
 version=2019-02-28

--- a/examples/standard-test.md
+++ b/examples/standard-test.md
@@ -10,10 +10,6 @@ There is one and only one column in `test_input_file.csv` containing the test ut
 
 ```
 [ASSISTANT CREDENTIALS]
-; If your WA environment provides username and password, configure them and leave iam_apikey empty
-; If your WA environment provides iam_apikey, set the username value as: apikey and password value as: <the value of your apikey>
-username = <wa username>
-password = <wa password>
 iam_apikey = <wa iam apikey>
 url = https://gateway-wdc.watsonplatform.net/assistant/api
 version=2019-02-28

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -25,7 +25,7 @@ tool_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, tool_base)
 from utils import FOLD_NUM_DEFAULT, KFOLD, BLIND_TEST, STANDARD_TEST, \
                   TRAIN_CONVERSATION_PATH, WCS_CREDS_SECTION, \
-                  WCS_USERNAME_ITEM, WCS_PASSWORD_ITEM, \
+                  WCS_IAM_APIKEY_ITEM, \
                   WORKSPACE_ID_TAG, SPEC_FILENAME, BOOL_MAP, \
                   delete_workspaces
 
@@ -70,11 +70,10 @@ class RunTestCase(CommandLineTestCase):
         entity_path = os.path.join(tool_base, 'resources', 'sample',
                                    'entities.csv')
 
-        username = self.config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = self.config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey   = self.config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i', intent_path,
-                '-e', entity_path, '-u', username, '-p', password]
+                '-e', entity_path, '-a', apikey]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
         # Train a new instance in order to pull the workspace detail
@@ -108,7 +107,7 @@ class RunTestCase(CommandLineTestCase):
         if subprocess.run(args).returncode != 0:
             raised = True
 
-        delete_workspaces(username, password,
+        delete_workspaces(apikey,
                           [self.config[DEFAULT_SECTION][WORKSPACE_ID_ITEM]])
 
         self.assertFalse(raised, 'Exception raised')
@@ -135,11 +134,10 @@ class RunTestCase(CommandLineTestCase):
                                                'sample', 'kfold', '1',
                                                'test-out.csv')
 
-        username = self.config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = self.config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey   = self.config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i', intent_path,
-                '-e', entity_path, '-u', username, '-p', password]
+                '-e', entity_path, '-a', apikey]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
         # Train a new instance in order to pull the workspace detail
@@ -177,7 +175,7 @@ class RunTestCase(CommandLineTestCase):
         if subprocess.run(args).returncode != 0:
             raised = True
 
-        delete_workspaces(username, password,
+        delete_workspaces(apikey,
                           [self.config[DEFAULT_SECTION][WORKSPACE_ID_ITEM]])
 
         self.assertFalse(raised, 'Exception raised')
@@ -197,11 +195,10 @@ class RunTestCase(CommandLineTestCase):
         entity_path = os.path.join(tool_base, 'resources', 'sample',
                                    'entities.csv')
 
-        username = self.config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = self.config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey   = self.config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i', intent_path,
-                '-e', entity_path, '-u', username, '-p', password]
+                '-e', entity_path, '-a', apikey]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
         # Train a new instance in order to pull the workspace detail
@@ -235,7 +232,7 @@ class RunTestCase(CommandLineTestCase):
         if subprocess.run(args).returncode != 0:
             raised = True
 
-        delete_workspaces(username, password,
+        delete_workspaces(apikey,
                           [self.config[DEFAULT_SECTION][WORKSPACE_ID_ITEM]])
 
         self.assertFalse(raised, 'Exception raised')

--- a/tests/test_testConversation.py
+++ b/tests/test_testConversation.py
@@ -24,7 +24,7 @@ import os
 tool_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, tool_base)
 from utils import TRAIN_CONVERSATION_PATH, TEST_CONVERSATION_PATH, \
-                  WCS_USERNAME_ITEM, WCS_PASSWORD_ITEM, WCS_CREDS_SECTION, \
+                  WCS_IAM_APIKEY_ITEM, WCS_CREDS_SECTION, \
                   DEFAULT_TEST_RATE, WORKSPACE_ID_TAG, SPEC_FILENAME, \
                   delete_workspaces
 
@@ -50,8 +50,7 @@ class TestConversationTestCase(CommandLineTestCase):
         config = configparser.ConfigParser()
         config.read(config_path)
 
-        username = config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey = config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         intent_path = os.path.join(tool_base, 'resources', 'sample',
                                    'intents.csv')
@@ -59,8 +58,7 @@ class TestConversationTestCase(CommandLineTestCase):
                                    'entities.csv')
 
         train_args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i',
-                      intent_path, '-e', entity_path, '-u', username, '-p',
-                      password]
+                      intent_path, '-e', entity_path, '-a', apikey]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
 
@@ -84,11 +82,10 @@ class TestConversationTestCase(CommandLineTestCase):
                     test_args = [sys.executable, self.script_path, '-i',
                                  test_in_path, '-o', test_out_path, '-w',
                                  workspace_id, '-t', 'utterance', '-m', '-g',
-                                 'golden intent', '-u', username, '-p',
-                                 password, '-r', str(DEFAULT_TEST_RATE)]
+                                 'golden intent', '-a', apikey, '-r', str(DEFAULT_TEST_RATE)]
                     print('Begin testing')
                     returncode = subprocess.run(test_args).returncode
-                    delete_workspaces(username, password, [workspace_id])
+                    delete_workspaces(apikey, [workspace_id])
                     if returncode != 0:
                         print('Testing failed')
                         raise Exception()

--- a/tests/test_trainConversation.py
+++ b/tests/test_trainConversation.py
@@ -23,7 +23,7 @@ import json
 import os
 tool_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, tool_base)
-from utils import WCS_USERNAME_ITEM, WCS_PASSWORD_ITEM, WCS_CREDS_SECTION, \
+from utils import WCS_IAM_APIKEY_ITEM, WCS_CREDS_SECTION, \
                   TRAIN_CONVERSATION_PATH, SPEC_FILENAME, delete_workspaces, \
                   WORKSPACE_ID_TAG
 
@@ -49,8 +49,7 @@ class TrainConversationTestCase(CommandLineTestCase):
         config = configparser.ConfigParser()
         config.read(config_path)
 
-        username = config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey = config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         intent_path = os.path.join(tool_base, 'resources', 'sample',
                                    'intents.csv')
@@ -58,8 +57,7 @@ class TrainConversationTestCase(CommandLineTestCase):
                                    'entities.csv')
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i',
-                intent_path, '-e', entity_path, '-u', username, '-p',
-                password]
+                intent_path, '-e', entity_path, '-a', apikey]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
 
@@ -77,7 +75,7 @@ class TrainConversationTestCase(CommandLineTestCase):
                 else:
                     print('Training complete')
                     workspace_id = json.load(f)[WORKSPACE_ID_TAG]
-                    delete_workspaces(username, password, [workspace_id])
+                    delete_workspaces(apikey, [workspace_id])
 
         except Exception as e:
             print(e)

--- a/tests/test_workspaceParser.py
+++ b/tests/test_workspaceParser.py
@@ -24,8 +24,8 @@ import os
 tool_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, tool_base)
 import workspaceParser
-from utils import WCS_CREDS_SECTION, WCS_USERNAME_ITEM, SPEC_FILENAME, \
-                  WCS_PASSWORD_ITEM, TRAIN_CONVERSATION_PATH, \
+from utils import WCS_CREDS_SECTION, SPEC_FILENAME, \
+                  WCS_IAM_APIKEY_ITEM, TRAIN_CONVERSATION_PATH, \
                   delete_workspaces, WORKSPACE_ID_TAG, DEFAULT_WA_VERSION
 
 
@@ -53,11 +53,10 @@ class WorkspaceParserTestCase(CommandLineTestCase):
         config = configparser.ConfigParser()
         config.read(config_path)
 
-        username = config[WCS_CREDS_SECTION][WCS_USERNAME_ITEM]
-        password = config[WCS_CREDS_SECTION][WCS_PASSWORD_ITEM]
+        apikey = config[WCS_CREDS_SECTION][WCS_IAM_APIKEY_ITEM]
 
         args = [sys.executable, TRAIN_CONVERSATION_PATH, '-i', intent_path,
-                '-e', entity_path, '-u', username, '-p', password, '-v', DEFAULT_WA_VERSION]
+                '-e', entity_path, '-a', apikey, '-v', DEFAULT_WA_VERSION]
 
         workspace_spec_json = os.path.join(self.test_dir, SPEC_FILENAME)
         # Train a new instance in order to pull the workspace detail
@@ -75,15 +74,15 @@ class WorkspaceParserTestCase(CommandLineTestCase):
 
         args = \
             self.parser.parse_args(
-                ['-w', workspace_id, '-u', username,
-                 '-p', password, '-o', self.test_dir])
+                ['-w', workspace_id, '-a', apikey,
+                 '-o', self.test_dir])
         try:
             workspaceParser.func(args)
         except Exception as e:
             print(e)
             raised = True
 
-        delete_workspaces(username, password,
+        delete_workspaces(apikey,
                           [workspace_id])
         self.assertFalse(raised, 'Exception raised')
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -39,8 +39,6 @@ DIALOG_RESPONSE_COLUMN = 'dialog response'
 GOLDEN_INTENT_COLUMN = 'golden intent'
 SCORE_COLUMN = 'score'
 
-WCS_USERNAME_ITEM = 'username'
-WCS_PASSWORD_ITEM = 'password'
 WCS_IAM_APIKEY_ITEM = 'iam_apikey'
 WCS_BASEURL_ITEM = 'url'
 WCS_CREDS_SECTION = 'ASSISTANT CREDENTIALS'
@@ -120,7 +118,7 @@ def unmarshall_entity(entities_str):
     return entities
 
 
-def delete_workspaces(username, password, iam_apikey, url, version, workspace_ids):
+def delete_workspaces(iam_apikey, url, version, workspace_ids):
     """ Delete workspaces
     """
     authenticator = IAMAuthenticator(iam_apikey)

--- a/utils/get_intent_description.py
+++ b/utils/get_intent_description.py
@@ -22,8 +22,6 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 import json
 import csv
 
-from __init__ import BASE_URL
-
 WA_API_VERSION = '2017-05-26'
 
 
@@ -36,7 +34,7 @@ def add_output_arg(parser):
 
 
 def get_remote_workspace(args):
-    authenticator = IAMAuthenticator(args.password)
+    authenticator = IAMAuthenticator(args.iam_apikey)
     conv = AssistantV1(
         version=WA_API_VERSION,
         authenticator=authenticator
@@ -81,23 +79,17 @@ if __name__ == '__main__':
     )
     add_output_arg(credentials_parser)
 
-    requiredNamed = credentials_parser.add_argument_group('required arguments')
-    requiredNamed.add_argument(
-        '--user', '-u',
-        help='Watson Assistant Username',
-        required=True
-    )
-    requiredNamed.add_argument(
-        '--password', '-p',
-        help='Watson Assistant Password',
-        required=True
-    )
-    requiredNamed.add_argument(
+    requiredNames = credentials_parser.add_argument_group('required arguments')
+    requiredNames.add_argument(
         '--workspace_id', '-w',
         help='Watson Assistant Workspace ID',
         required=True
     )
-    requiredNamed.add_argument(
+    requiredNames.add_argument(
+        '--iam_apikey', '-a',
+        help='Assistant service IAM api key',
+        required=True),
+    requiredNames.add_argument(
         '--url', '-l',
         help='Watson Assistant Url',
         default='https://gateway.watsonplatform.net/assistant/api'

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -23,6 +23,8 @@ import asyncio
 import pandas as pd
 from argparse import ArgumentParser
 import aiohttp
+from ibm_watson import AssistantV1
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
 from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \
@@ -38,24 +40,30 @@ test_out_header = [PREDICTED_INTENT_COLUMN, CONFIDENCE_COLUMN,
 MAX_RETRY_LIMIT = 5
 
 
-async def post(session, json, url, sem):
+async def message(service, workspace_id, utterance):
+    # Include user_id in request body for Plus and Premium plans
+    response = service.message(
+        workspace_id=workspace_id,
+        input={
+            'text': utterance,
+            'alternate_intents': True
+        },
+        context={
+            'metadata': {
+                'user_id': 'test'
+            }
+        })
+    return response.get_result()
+
+async def post(service, workspace_id, utterance, sem):
     """ Single post restrained by semaphore
     """
     counter = 0
     async with sem:
         while True:
             try:
-                # Include user_id in request body for Plus and Premium plans
-                json.update({
-                    'context': {
-                        'metadata': {
-                            'user_id': 'test'
-                        }
-                    }
-                })
-                async with session.post(url, json=json, raise_for_status=True) as response:
-                    res = await response.json()
-                    return res
+                res = await message(service, workspace_id, utterance)
+                return res
             except Exception as e:
                 # Max retries reached, print out the response payload
                 if counter == MAX_RETRY_LIMIT:
@@ -66,19 +74,13 @@ async def post(session, json, url, sem):
                 print(counter)
 
 
-async def fill_df(utterance, row_idx, out_df, workspace_id, wa_username,
-                  wa_password, sem, baseUrl, version):
-    """ Send utterance to Assistant and save response to dataframe
-    """
-    async with aiohttp.ClientSession(
-            auth=aiohttp.BasicAuth(wa_username, wa_password)) as session:
-        MSG_ENDPOINT = baseUrl + '/v1/workspaces/{}/message?version={}'
-        url = MSG_ENDPOINT.format(workspace_id, version)
-
+async def fill_df(utterance, row_idx, out_df, workspace_id, conversation, sem):
+        """ Send utterance to Assistant and save response to dataframe
+        """
+#    async:
         # Replace newline chars before sending to WA
         utterance = utterance.replace('\n', ' ')
-        resp = await post(session, {'input': {'text': utterance},
-                                    'alternate_intents': True}, url, sem)
+        resp = await post(conversation, workspace_id, utterance, sem)
         try:
             intents = resp['intents']
 
@@ -137,9 +139,16 @@ def func(args):
     sem = asyncio.Semaphore(args.rate_limit)
     loop = asyncio.get_event_loop()
 
+    authenticator = IAMAuthenticator(args.iam_apikey)
+    conv = AssistantV1(
+        version=args.version,
+        authenticator=authenticator
+    )
+    conv.set_service_url(args.url)
+
     tasks = (fill_df(out_df.loc[row_idx, test_column],
-                     row_idx, out_df, args.workspace_id,
-                     args.username, args.password, sem, args.url, args.version)
+                     row_idx, out_df, args.workspace_id, conv,
+                     sem)
              for row_idx in range(out_df.shape[0]))
     loop.run_until_complete(asyncio.gather(*tasks))
 
@@ -211,4 +220,6 @@ def create_parser():
 
 if __name__ == '__main__':
     ARGS = create_parser().parse_args()
+    #for arg in vars(ARGS):
+    #    print("{} {}".format(arg, getattr(ARGS, arg)))
     func(ARGS)

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -194,12 +194,8 @@ def create_parser():
                         default=os.path.join(os.getcwd(), TEST_OUT_FILENAME))
     parser.add_argument('-w', '--workspace_id', type=str, required=True,
                         help='Workspace ID')
-    parser.add_argument('-u', '--username', type=str, required=True,
-                        help='Assistant service username')
-    parser.add_argument('-p', '--password', type=str, required=True,
-                        help='Assistant service password')
     parser.add_argument('-a', '--iam_apikey', type=str, required=True,
-                        help='Assistant service iam api key')
+                        help='Assistant service IAM api key')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/assistant/api',
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-t', '--test_column', type=str,

--- a/utils/trainConversation.py
+++ b/utils/trainConversation.py
@@ -228,12 +228,8 @@ def create_parser():
                         help='Workspace name')
     parser.add_argument('-d', '--workspace_description', type=str,
                         help='Workspace description')
-    parser.add_argument('-u', '--username', type=str, required=True,
-                        help='Assistant service username')
     parser.add_argument('-a', '--iam_apikey', type=str, required=True,
-                        help='Assistant service iam api key')
-    parser.add_argument('-p', '--password', type=str, required=True,
-                        help='Assistant service password')
+                        help='Assistant service IAM api key')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/assistant/api',
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,

--- a/utils/workspaceParser.py
+++ b/utils/workspaceParser.py
@@ -93,10 +93,6 @@ def create_parser():
         description="Parse workspace into artifacts for training")
     parser.add_argument('-i', '--input', type=str, required=True,
                         help='Workspace ID or path of workspace JSON')
-    parser.add_argument('-u', '--username', type=str, required=True,
-                        help='Assistant service username')
-    parser.add_argument('-p', '--password', type=str, required=True,
-                        help='Assistant service password')
     parser.add_argument('-a', '--iam_apikey', type=str, required=True,
                         help='Assistant service iam api key')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/assistant/api',

--- a/validate_workspace/README.md
+++ b/validate_workspace/README.md
@@ -6,7 +6,7 @@ This is a syntax validator for Watson Assistant workspaces (skills) that integra
 Gather the information needed to connect to your workspace.  You can run the tool against a local copy of the workspace or can use the remote copy.
 
 Export the Watson Assistant workspace you wish to validate: https://developer.ibm.com/tutorials/learn-how-to-export-import-a-watson-assistant-workspace/
-Or gather the username/password, URL, and workspace ID.
+Or gather the IAM apikey, URL, and workspace ID.
 
 *Execution steps*
 You are required to provide:
@@ -15,7 +15,7 @@ You are required to provide:
 
 A local file is referenced with "`-f` your_filename_here".
 
-A online connection to the workspace is referenced with "`-o` `--username` your_username_here `--password` your_password_here `--url` your_url_here `--workspace_id` your_workspace_id_here".
+A online connection to the workspace is referenced with "`-o` `--apikey` your_apikey_here `--url` your_url_here `--workspace_id` your_workspace_id_here".
 
 To validate a workspace against an SOE contract, invoke with `-s`.  You can optionally specify the legal "route" values with `--soe_route`
 

--- a/validate_workspace/validateWS.py
+++ b/validate_workspace/validateWS.py
@@ -217,7 +217,7 @@ def buildJumpReport(workspace, jumpReportFile, jumpLabel):
    jumps = []
    for dialogNode in workspace.getDialogNodes():
        if(getTargetTitles):
-          idToTitleDict[dialogNode.getId()] = dialogNode.getTitle() 
+          idToTitleDict[dialogNode.getId()] = dialogNode.getTitle()
        if 'jump_to' == dialogNode.getNextStep():
            behavior = dialogNode.data['next_step']
            type = behavior['selector'] #'body' or 'condition'
@@ -242,7 +242,7 @@ def buildJumpReport(workspace, jumpReportFile, jumpLabel):
           target = target + ":" + idToTitleDict[target]
 
        line = '{}\t{}\t{}'.format(source, jump['type'], target)
-       outFile.write(line+'\n') 
+       outFile.write(line+'\n')
    outFile.close()
    print('Wrote jump report file to {}'.format(jumpReportFile))
 
@@ -252,7 +252,7 @@ def getWorkspaceJson(args):
     return json.load(jsonFile)
   if args.online:
     VERSION='2018-09-20'
-    authenticator = IAMAuthenticator(args.password[0])
+    authenticator = IAMAuthenticator(args.iam_apikey[0])
     service = AssistantV1(
         version=VERSION,
         authenticator=authenticator
@@ -287,9 +287,8 @@ if __name__ == '__main__':
     parser.add_argument('--soe_routes', help='Comma-separated list of SOE action routes. Ex: "SOE,API,None"', default='SOE,API,None')
     parser.add_argument('--jump_report', help='Filename to print a report of all jumps in the workspace')
     parser.add_argument('--jump_labels', help='When building jump report, label the nodes by `ID|Title|Both`', default='Both')
-    parser.add_argument('-u', '--username', nargs=1, type=str, help='Username to Watson Assistant.')
-    parser.add_argument('-p', '--password', nargs=1, type=str, help='Password to Watson Assistant.')
-    parser.add_argument('-l', '--url', nargs=1, type=str, help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
+    parser.add_argument('-a', '--iam_apikey', nargs=1, type=str, required=True, help='Assistant service IAM api key')
+    parser.add_argument('-l', '--url', type=str, help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-w', '--workspace_id', nargs=1, type=str, help='ID of the Watson Assistant workspace')
 
     args = parser.parse_args()


### PR DESCRIPTION
As of October 30, 2019 only IAM-based authentication will be allowed.
This pull request removes the basic authentication options completely from code and documentation, addressing Issue #100 .

I ran unit tests in six modes:
* kfold
* test
* blind
* validate_workspace
* get_intent_description
* flowtest

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>