### PR TITLE
configurable kfold output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2019-12-02
+### Added
+- Configurable k-fold union output file name
+
 ## 2019-11-15
 ### Added
 - Support for testing Natural Language Classifier models

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -47,7 +47,7 @@ mode = kfold
 ;   In test mode column header is 'utterance'
 ; test_input_file = ./data/test.csv
 
-; (Optional for blind and test) Test output path. Defaults to <temp_dir>/<mode>-out.csv
+; (Optional for all modes) Test output path. Defaults to <temp_dir>/<mode>-out.csv
 ; test_output_path = ./data/test-out.csv
 
 ; (Optional for blind and kfold) Output figure path. Defaults to <temp_dir>/<mode>.png

--- a/notebook_ws/WA-Testing-Tool-WS-Python-Notebook.ipynb
+++ b/notebook_ws/WA-Testing-Tool-WS-Python-Notebook.ipynb
@@ -738,7 +738,7 @@
    "outputs": [],
    "source": [
     "# Examples, to get the output files to Assets\n",
-    "# To get the results csv files (eg kfold-test-out-union.csv, test-out.csv etc) \n",
+    "# To get the results csv files (eg kfold-out.csv, test-out.csv etc) \n",
     "# to project Assets edit the file name and uncomment below\n",
     "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH, '<output-file-name>')"
    ]
@@ -996,12 +996,12 @@
     "#Read test output file into a df\n",
     "\n",
     "#For golden/predicted for kfold test\n",
-    "#os.listdir(WA_TOOL_DATA_DIR_W_PATH+'/kfold/kfold-test-out-union.csv') # (./wa-tooling-notebook/WA-Testing-Tool/data/kfold/kfold-test-out-union.csv\")\n",
-    "df_test_output_kfold = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.csv')\n",
+    "#os.listdir(WA_TOOL_DATA_DIR_W_PATH+'/kfold/kfold-out.csv') # (./wa-tooling-notebook/WA-Testing-Tool/data/kfold/kfold-out.csv\")\n",
+    "df_test_output_kfold = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.csv')\n",
     "df_test_output_kfold.head(10)\n",
     "\n",
     "# Copy this file to project Assets\n",
-    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.csv')"
+    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.csv')"
    ]
   },
   {
@@ -1103,11 +1103,11 @@
    ],
    "source": [
     "#For confusion matrix for kfold test\n",
-    "df_test_output_kfold_conf_args = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.confusion_args.csv')\n",
+    "df_test_output_kfold_conf_args = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.confusion_args.csv')\n",
     "df_test_output_kfold_conf_args.head(50)\n",
     "\n",
     "# Copy this file to project Assets\n",
-    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.confusion_args.csv')"
+    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.confusion_args.csv')"
    ]
   },
   {
@@ -1129,10 +1129,10 @@
    ],
    "source": [
     "# Chart\n",
-    "Image(filename=WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.confusion_args.png')\n",
+    "Image(filename=WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.confusion_args.png')\n",
     "\n",
     "# Copy this file to project Assets\n",
-    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.confusion_args.png')"
+    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.confusion_args.png')"
    ]
   },
   {
@@ -1240,11 +1240,11 @@
    ],
    "source": [
     "#For metrics for kfold test\n",
-    "df_test_output_kfold_metrics = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.metrics.csv')\n",
+    "df_test_output_kfold_metrics = pd.read_csv(WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.metrics.csv')\n",
     "df_test_output_kfold_metrics.head(50)\n",
     "\n",
     "# Copy this file to project Assets\n",
-    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-test-out-union.metrics.csv')"
+    "#copy_python_env_file_to_project_asset(project, WA_TOOL_DATA_DIR_W_PATH+'/kfold-out.metrics.csv')"
    ]
   },
   {


### PR DESCRIPTION
kfold output path is set by `test_output_path` same as the other modes.

Solves #123 

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>