### PR TITLE
#138 Allow pandas 1.0.1 and higher, only 1.0.0 was broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.3
-pandas>=0.21,<1.0.0
+pandas>=0.21
 scikit-learn>=0.19.1
 scipy>=1.0.0
 matplotlib>=2.1.2


### PR DESCRIPTION
Remove pandas version restriction

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>