### PR TITLE
Response returned by Watson Assistant isn't type string

### DIFF
--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -95,6 +95,7 @@ async def fill_df(utterance, row_idx, out_df, workspace_id, conversation, sem):
             response_text = ''
             response_text_list = resp['output']['text']
             if len(response_text_list) != 0:
+                response_text_list = [text for text in response_text_list if type(text) == str]
                 response_text = ' '.join(response_text_list)
 
             out_df.loc[row_idx, DIALOG_RESPONSE_COLUMN] = response_text


### PR DESCRIPTION
## TLDR;
Edge-case to handle weird instances when the response returned by the Assistant is not always a string

## Issue
The ` ' '.join(respone_text_list)` will fail if the items in the list are not type string. I encountered this edge case when running the notebook for the client, and they returned a blank dictionary, `{}`,  to the user (see attached). This is an issue that needs to be fixed at the client site, but added this extra check for robustness. 

![image](https://user-images.githubusercontent.com/22038870/78839881-03577880-79bf-11ea-8fbd-d2aadb2a8e5d.png)

DCO 1.1 Signed-off-by: Pratyush Singh <pratyushsingh@ibm.com>