### PR TITLE
Precision & Recall Errors and Pandas Deprecation Fix

### DIFF
--- a/utils/createPrecisionCurve.py
+++ b/utils/createPrecisionCurve.py
@@ -52,7 +52,7 @@ def func(args):
     classifier_stat_list = []
     cf_frames = []
     confidences_list = []
-    intents_in_results = pd.Series()
+    intents_in_results = pd.Series(dtype=float)
 
     classifier_num = len(args.classifiers_results)
 

--- a/utils/intentmetrics.py
+++ b/utils/intentmetrics.py
@@ -17,6 +17,7 @@
 """ Generate per intent metrics on True Positive/False Positives
 """
 import csv
+import math
 import pandas as pd
 from argparse import ArgumentParser
 from sklearn.metrics import precision_recall_fscore_support
@@ -37,10 +38,12 @@ def func(args):
 
     labels = in_df[args.golden_column].drop_duplicates().sort_values()
 
+    # if there are no True Positives then set the precision, recall, and f-score to 0
     precisions, recalls, fscores, support = \
         precision_recall_fscore_support(y_true=in_df[args.golden_column],
                                         y_pred=in_df[args.test_column],
-                                        labels=labels)
+                                        labels=labels,
+                                        zero_division=0)
 
     #Raw accuracy as well
     in_df['correct'] = (in_df[args.golden_column] == in_df[args.test_column])
@@ -55,12 +58,16 @@ def func(args):
             retrieved_doc_num = len(in_df[retrieved_doc_indx])
             relevant_doc_num  = len(in_df[relevant_doc_indx])
 
-            precision = in_df[retrieved_doc_indx]['score'].sum() / retrieved_doc_num
-            recall = in_df[relevant_doc_indx]['score'].sum()/ relevant_doc_num
+            precision = in_df[retrieved_doc_indx]['score'].sum() / retrieved_doc_num if retrieved_doc_num != 0 else 0
+            recall = in_df[relevant_doc_indx]['score'].sum()/ relevant_doc_num if relevant_doc_num else 0
 
             precisions[idx] = precision
             recalls[idx] = recall
-            fscores[idx] = (2 * precision * recall) / (precision + recall)
+            fscores[idx] = 0
+
+            # handling edge case where precision and recall are 0. Avoids DivideByZeroError
+            if precision != 0.0 and recall != 0.0:
+                fscores[idx] = (2 * precision * recall) / (precision + recall)
 
     out_df = pd.DataFrame(data={'intent': labels,
                                 'recall': recalls,

--- a/utils/intentmetrics.py
+++ b/utils/intentmetrics.py
@@ -82,7 +82,9 @@ def func(args):
     print ("Wrote intent metrics output to {}. Includes {} correct intents in {} tries for accuracy of {}.".format(args.out_file, num_correct, samples, accuracy))
 
     # Fill f-score column with the recall when the precision is undefined.  Produces a more actionable tree map especially in partial-credit scenarios.
-    out_df.loc[out_df['precision'].isnull(),'f-score'] = out_df['recall']
+    if args.partial_credit_on is not None:
+        out_df.loc[out_df['precision'] == 0.0,'f-score'] = out_df['recall']
+    
     generateTreemap(args.out_file, out_df)
 
 def generateTreemap(base_out_file, out_df):

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -95,6 +95,7 @@ async def fill_df(utterance, row_idx, out_df, workspace_id, conversation, sem):
             response_text = ''
             response_text_list = resp['output']['text']
             if len(response_text_list) != 0:
+                response_text_list = [text for text in response_text_list if type(text) == str]
                 response_text = ' '.join(response_text_list)
 
             out_df.loc[row_idx, DIALOG_RESPONSE_COLUMN] = response_text


### PR DESCRIPTION
1. Fixed the pandas deprecation warning on the default datatype
2. Fixed `ZeroDivisionError`  when calling `precision_recall_fscore_support` by making precision, recall, and f1 default to 0 when there are not any predicted true labels
3. Added extra error checking to avoid `ZeroDivisionError` when calculating individual precision, recall, and f1 scores. 

DCO 1.1 Signed-off-by: Pratyush Singh <pratyushsingh@ibm.com>