### PR TITLE
Updated requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.13.3
-pandas>= 0.22.0
-scikit-learn>=0.19.1
+pandas>=0.21
+scikit-learn>=0.22.0
 scipy>=1.0.0
 matplotlib>=2.1.2
 aiohttp>=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.3
-pandas>=0.21
+pandas>= 0.22.0
 scikit-learn>=0.19.1
 scipy>=1.0.0
 matplotlib>=2.1.2

--- a/utils/createPrecisionCurve.py
+++ b/utils/createPrecisionCurve.py
@@ -52,7 +52,7 @@ def func(args):
     classifier_stat_list = []
     cf_frames = []
     confidences_list = []
-    intents_in_results = pd.Series()
+    intents_in_results = pd.Series(dtype='float')
 
     classifier_num = len(args.classifiers_results)
 


### PR DESCRIPTION
Updated _requirements.txt_ file to install `scikit-learn > 0.22` to support the `zero_division` parameter in `precision_recall_fscore_support`. 

Also somehow the explicit datatype in `pd.Series()` in _createPrecisionCurve_ didn't make it through previously. I added that as well. 

DCO 1.1 Signed-off-by: Pratyush Singh <pratyushsingh@ibm.com>