### PR TITLE
make use of regexp patterns explicit + friendlier multiline

### DIFF
--- a/dialog_test/README.md
+++ b/dialog_test/README.md
@@ -30,6 +30,6 @@ The columns are
 
 All fields are optional
 
-* Match Output indicates a substring that must be present in the Watson Assistant response. It is not necessary to provide the full input string.
+* Match Output indicates a substring that must be present in the Watson Assistant response. It is not necessary to provide the full output string. Regular Expressions can be enclosed with forward slashes (e.g. `/The reservation is for *. PM/`). `<br>` can be used to join lines when specifyig multiline ouputs (e.g. `The reservation is for 6 guests<br>What day would you like to come in?`).
 
 If the User Input column is exactly 'NEWCONVERSATION' (no quotes) then a new conversation is started.  This allows multiple tests in the same file.

--- a/dialog_test/flowtest_v1.py
+++ b/dialog_test/flowtest_v1.py
@@ -194,7 +194,10 @@ class FlowTestV1:
                 if 'text' in r['output']:
                   innerText = r['output']['text']
                 if row['Match Output'] != '':
-                    matchedOutput = bool(re.search(row['Match Output'], '\n'.join(innerText)))
+                    row['Match Output'] = '<br>'.join(row['Match Output'].splitlines())
+                    ouput_pattern = row['Match Output']
+                    ouput_pattern = re.escape(ouput_pattern) if not ouput_pattern.startswith('/') else ouput_pattern[1:-1]
+                    matchedOutput = bool(re.search(ouput_pattern, '<br>'.join(innerText), re.MULTILINE))
                     if matchedOutput == False:
                       self.reportFailure()
                 else:
@@ -226,7 +229,7 @@ class FlowTestV1:
 
                 record = { 
                     'User Input': row['User Input'],
-                    'Output Text': '\n'.join(r['output']['text']),
+                    'Output Text': '<br>'.join(r['output']['text']),
                     'Alternate Intents': ai,
                     'Conversation ID': r['context']['conversation_id'],
                     'Context': r['context'],


### PR DESCRIPTION
BEFORE:
* expected ouput is used as a regexp pattern. If an ouput specification
  contains characters (e.g, `()`), tests fail even if the spec matches
  the output character by character.
* multiline output make the TSV files very hard to work with, because a
  record expands more than one row. Excel does not read it, and using an
  editor is unintuitive because the columns are missaligned.

AFTER:
* the expected output is run through re.escape() before searching. This
  behaviour is avoided if the specification is enclosed by forward slashes.
  This can break backward compatibility for users that rely on the
  undocumented fact that the the output specification was treated as a regexp
  pattern instead of as a string
* multiline output specifications can use `<br>` instead of line breaks.
  Output specifications with line breaks are still properly processed.
  The test reports use `<br>` use instead of line breaks.

DCO 1.1 Signed-off-by: Xavier Vergés xverges@gmail.com