### PR TITLE
Add Cloud Pak For Data Authentication Support

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -5,6 +5,9 @@
 iam_apikey =
 url = https://api.us-south.assistant.watson.cloud.ibm.com
 
+; Cloud Pak 4 Data requires the "bearer" auth_type. "iam" is default.
+; auth_type = bearer
+
 ; Instances created before December 13, 2019 have a url with this pattern
 ;url = https://gateway.watsonplatform.net/assistant/api
 

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -5,8 +5,10 @@
 iam_apikey =
 url = https://api.us-south.assistant.watson.cloud.ibm.com
 
-; Cloud Pak 4 Data requires the "bearer" auth_type. "iam" is default.
-; auth_type = bearer
+; Cloud Pak 4 Data (CP4D) requires the "bearer" auth_type. "iam" is default. 
+; to use "bearer" authentication, set "auth_type" below to bearer, and the iam_apikey will be
+; interpreted as a bearer token instead.
+;auth_type = bearer
 
 ; Instances created before December 13, 2019 have a url with this pattern
 ;url = https://gateway.watsonplatform.net/assistant/api

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -20,7 +20,7 @@ import os
 import pandas as pd
 from ibm_watson import AssistantV1
 from ibm_watson import NaturalLanguageClassifierV1
-from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
 
 UTF_8 = 'utf-8'
 TRAIN_FILENAME = 'train.csv'
@@ -41,6 +41,7 @@ GOLDEN_INTENT_COLUMN = 'golden intent'
 SCORE_COLUMN = 'score'
 
 WCS_IAM_APIKEY_ITEM = 'iam_apikey'
+WCS_AUTH_TYPE_ITEM = 'auth_type'
 WCS_BASEURL_ITEM = 'url'
 WCS_CREDS_SECTION = 'ASSISTANT CREDENTIALS'
 WA_API_VERSION_ITEM = 'version'
@@ -124,10 +125,15 @@ def unmarshall_entity(entities_str):
     return entities
 
 
-def delete_workspaces(iam_apikey, url, version, workspace_ids):
+def delete_workspaces(iam_apikey, url, version, workspace_ids, auth_type):
     """ Delete workspaces
     """
-    authenticator = IAMAuthenticator(iam_apikey)
+    if auth_type == 'iam':
+        authenticator = IAMAuthenticator(iam_apikey)
+    elif auth_type == 'bearer':
+        authenticator = BearerTokenAuthenticator(iam_apikey)
+    else:
+        raise ValueError(f'Unknown auth_type "{auth_type}"')
     
     for workspace_id in workspace_ids:
         if 'natural-language-classifier' in url:

--- a/utils/choose_auth.py
+++ b/utils/choose_auth.py
@@ -1,0 +1,16 @@
+from ibm_cloud_sdk_core.authenticators import BearerTokenAuthenticator, IAMAuthenticator, Authenticator
+from argparse import Namespace
+
+def choose_auth(args: Namespace) -> Authenticator:
+    """
+    Choose the authenticator type
+
+    :param args:
+    :return:
+    """
+    if args.auth_type == 'iam':
+        return IAMAuthenticator(args.iam_apikey)
+    elif args.auth_type == 'bearer':
+        return BearerTokenAuthenticator(args.iam_apikey)
+    else:
+        raise ValueError(f'Unknown auth type: "{args.auth_type}"')

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -24,7 +24,8 @@ import pandas as pd
 from argparse import ArgumentParser
 import aiohttp
 from ibm_watson import AssistantV1
-from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+
+from utils.choose_auth import choose_auth
 
 from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \
@@ -139,7 +140,8 @@ def func(args):
     sem = asyncio.Semaphore(args.rate_limit)
     loop = asyncio.get_event_loop()
 
-    authenticator = IAMAuthenticator(args.iam_apikey)
+    authenticator = choose_auth(args)
+
     conv = AssistantV1(
         version=args.version,
         authenticator=authenticator
@@ -211,6 +213,8 @@ def create_parser():
                         help='Partial credit table')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
                         help='Watson Assistant API version in YYYY-MM-DD form')
+    parser.add_argument('--auth-type', type=str, choices=['iam', 'bearer'], default='iam',
+                        help='Type of authentication. CP4D requires bearer.')
     return parser
 
 

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -213,8 +213,8 @@ def create_parser():
                         help='Partial credit table')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
                         help='Watson Assistant API version in YYYY-MM-DD form')
-    parser.add_argument('--auth-type', type=str, choices=['iam', 'bearer'], default='iam',
-                        help='Type of authentication. CP4D requires bearer.')
+    parser.add_argument('--auth-type', type=str, default='iam',
+                        help='Authentication type, IAM is default, bearer is required for CP4D.', choices=['iam', 'bearer'])
     return parser
 
 

--- a/utils/testConversation.py
+++ b/utils/testConversation.py
@@ -25,7 +25,7 @@ from argparse import ArgumentParser
 import aiohttp
 from ibm_watson import AssistantV1
 
-from utils.choose_auth import choose_auth
+from choose_auth import choose_auth
 
 from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \

--- a/utils/testNLC.py
+++ b/utils/testNLC.py
@@ -26,7 +26,7 @@ import aiohttp
 from ibm_watson import NaturalLanguageClassifierV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
 
-from utils.choose_auth import choose_auth
+from choose_auth import choose_auth
 
 from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \

--- a/utils/testNLC.py
+++ b/utils/testNLC.py
@@ -193,8 +193,8 @@ def create_parser():
                         help='Maximum number of requests per second')
     parser.add_argument('-c', '--partial_credit_table', type=str,
                         help='Partial credit table')
-    parser.add_argument('--auth-type', choices=['iam', 'bearer'], default='iam',
-                        help='Choose the authentication type. CP4D requires bearer, default is IAM.')
+    parser.add_argument('--auth-type', type=str, default='iam',
+                        help='Authentication type, IAM is default, bearer is required for CP4D.', choices=['iam', 'bearer'])
     return parser
 
 

--- a/utils/testNLC.py
+++ b/utils/testNLC.py
@@ -24,7 +24,9 @@ import pandas as pd
 from argparse import ArgumentParser
 import aiohttp
 from ibm_watson import NaturalLanguageClassifierV1
-from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
+
+from utils.choose_auth import choose_auth
 
 from __init__ import UTF_8, CONFIDENCE_COLUMN, \
     UTTERANCE_COLUMN, PREDICTED_INTENT_COLUMN, \
@@ -121,7 +123,8 @@ def func(args):
     sem = asyncio.Semaphore(args.rate_limit)
     loop = asyncio.get_event_loop()
 
-    authenticator = IAMAuthenticator(args.iam_apikey)
+    authenticator = choose_auth(args)
+
     nlc = NaturalLanguageClassifierV1(
         authenticator=authenticator
     )
@@ -190,6 +193,8 @@ def create_parser():
                         help='Maximum number of requests per second')
     parser.add_argument('-c', '--partial_credit_table', type=str,
                         help='Partial credit table')
+    parser.add_argument('--auth-type', choices=['iam', 'bearer'], default='iam',
+                        help='Choose the authentication type. CP4D requires bearer, default is IAM.')
     return parser
 
 

--- a/utils/trainConversation.py
+++ b/utils/trainConversation.py
@@ -237,8 +237,8 @@ def create_parser():
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
                         help='Watson Assistant API version in YYYY-MM-DD form')
-    parser.add_argument('--auth-type', type=str, required=True, choices=['iam', 'bearer'], default='iam',
-                        help='Type of authenticator. CP4D requires bearer.')
+    parser.add_argument('--auth-type', type=str, default='iam',
+                        help='Authentication type, IAM is default, bearer is required for CP4D.', choices=['iam', 'bearer'])
 
     return parser
 

--- a/utils/trainConversation.py
+++ b/utils/trainConversation.py
@@ -27,9 +27,11 @@ import csv
 import pandas as pd
 from argparse import ArgumentParser
 from ibm_watson import AssistantV1
-from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
 import sys
 import traceback
+
+from utils.choose_auth import choose_auth
 
 from __init__ import UTF_8, DEFAULT_WA_VERSION,\
                   UTTERANCE_COLUMN, INTENT_COLUMN, \
@@ -170,7 +172,8 @@ def func(args):
                      'values': row[ENTITY_VALUES_ARR_COLUMN]}
                     for _, row in entity_df.iterrows()]
 
-    authenticator = IAMAuthenticator(args.iam_apikey)
+    authenticator = choose_auth(args)
+
     conv = AssistantV1(
         version=args.version,
         authenticator=authenticator
@@ -234,6 +237,8 @@ def create_parser():
                         help='URL to Watson Assistant. Ex: https://gateway-wdc.watsonplatform.net/assistant/api')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WA_VERSION,
                         help='Watson Assistant API version in YYYY-MM-DD form')
+    parser.add_argument('--auth-type', type=str, required=True, choices=['iam', 'bearer'], default='iam',
+                        help='Type of authenticator. CP4D requires bearer.')
 
     return parser
 

--- a/utils/trainConversation.py
+++ b/utils/trainConversation.py
@@ -31,7 +31,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthe
 import sys
 import traceback
 
-from utils.choose_auth import choose_auth
+from choose_auth import choose_auth
 
 from __init__ import UTF_8, DEFAULT_WA_VERSION,\
                   UTTERANCE_COLUMN, INTENT_COLUMN, \

--- a/utils/trainNLC.py
+++ b/utils/trainNLC.py
@@ -27,6 +27,8 @@ from argparse import ArgumentParser
 from ibm_watson import NaturalLanguageClassifierV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
+from choose_auth import choose_auth
+
 from __init__ import UTF_8, \
                   UTTERANCE_COLUMN, INTENT_COLUMN, \
                   TIME_TO_WAIT, CLASSIFIER_ID_TAG
@@ -49,7 +51,8 @@ def func(args):
     metadata = {}
     learning_opt_out = False
 
-    authenticator = IAMAuthenticator(args.iam_apikey)
+    authenticator = choose_auth(args)
+
     nlc = NaturalLanguageClassifierV1(
         authenticator=authenticator
     )    
@@ -92,7 +95,8 @@ def create_parser():
                         help='Classifier name')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/natural_language_classifier/api',
                         help='URL to Watson NLC. Ex: https://gateway.watsonplatform.net/natural_language_classifier/api')
-
+    parser.add_argument('--auth-type', choices=['iam', 'bearer'], default='iam',
+                        help='Choose between iam (default) and bearer token')
     return parser
 
 if __name__ == '__main__':

--- a/utils/trainNLC.py
+++ b/utils/trainNLC.py
@@ -95,8 +95,8 @@ def create_parser():
                         help='Classifier name')
     parser.add_argument('-l', '--url', type=str, default='https://gateway.watsonplatform.net/natural_language_classifier/api',
                         help='URL to Watson NLC. Ex: https://gateway.watsonplatform.net/natural_language_classifier/api')
-    parser.add_argument('--auth-type', choices=['iam', 'bearer'], default='iam',
-                        help='Choose between iam (default) and bearer token')
+    parser.add_argument('--auth-type', type=str, default='iam',
+                        help='Authentication type, IAM is default, bearer is required for CP4D.', choices=['iam', 'bearer'])
     return parser
 
 if __name__ == '__main__':

--- a/utils/workspaceParser.py
+++ b/utils/workspaceParser.py
@@ -24,6 +24,7 @@ import json
 import os.path
 from argparse import ArgumentParser
 from ibm_watson import AssistantV1
+from choose_auth import choose_auth
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
 from __init__ import TRAIN_INTENT_FILENAME, DEFAULT_WA_VERSION, \
                      TRAIN_ENTITY_FILENAME, WORKSPACE_BASE_FILENAME, UTF_8
@@ -32,12 +33,8 @@ from __init__ import TRAIN_INTENT_FILENAME, DEFAULT_WA_VERSION, \
 def func(args):
     workspace = None
     if not os.path.isfile(args.input):
-        if args.auth_type == 'iam':
-            authenticator = IAMAuthenticator(args.iam_apikey)
-        elif args.auth_type == 'bearer':
-            authenticator = BearerTokenAuthenticator(args.iam_apikey)
-        else:
-            raise ValueError(f'Invalid auth_type: "{args.auth_type}"')
+        authenticator = choose_auth(args)
+
         conv = AssistantV1(
             version=args.version,
             authenticator=authenticator


### PR DESCRIPTION
Cloud Pak For Data (CP4D) uses a [slightly different authentication mechanism](https://cloud.ibm.com/apidocs/cloud-pak-data#getauthorizationtoken) than the standard IAM Token. This PR adds the [BearerTokenAuthenticator](https://github.com/IBM/python-sdk-core/blob/master/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py) from ibm_cloud_sdk_core to support authentication via the user-based bearer token CP4D users can find in their instances' service details page.

This PR adds an `auth_type` key to the config.ini file, and `--auth-type` args to the commandline programs to choose between "bearer" and "iam" and uses the supplied `iam_apikey` as either the IAM key (default) or bearer token if "bearer" is specified.

Filed [Issue 175](https://github.com/cognitive-catalyst/WA-Testing-Tool/issues/175) to correspond to this PR.