### PR TITLE
#201 status indicator during log fetch

### DIFF
--- a/log_analytics/getAllLogs.py
+++ b/log_analytics/getAllLogs.py
@@ -56,7 +56,7 @@ def getLogsInternal(assistant, workspace_id, filter, page_size_limit=DEFAULT_PAG
         if 'logs' in logs:
            allLogs.extend(logs['logs'])
            pages_retrieved = pages_retrieved + 1
-           print("Fetched {} log pages".format(pages_retrieved))
+           print("Fetched {} log pages with {} total logs".format(pages_retrieved, len(allLogs)))
         else:
            return None
 
@@ -75,7 +75,7 @@ def writeLogs(logs, output_file, output_columns="raw"):
     file = None
     if output_file != None:
        file = open(output_file,'w')
-       print("Writing logs to", output_file)   
+       print("Writing {} logs to {}".format(len(logs), output_file))
 
     if 'raw' == output_columns: 
        writeOut(file, json.dumps(logs,indent=2))


### PR DESCRIPTION
Fixes #201 

Example progress:
```
afreed@andrews-mbp:[~/Code/WA-Testing-Tool/log_analytics] (master *)$ python getAllLogs.py -a <snipped> -l https://api.us-east.assistant.watson.cloud.ibm.com/instances/<snipped> -w <snipped> -n 2 -p 10 -f "request_timestamp>2021-10-01" -o test.json
Fetched 1 log pages with 10 total logs
Fetched 2 log pages with 20 total logs
Writing 20 logs to test.json
```

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>