### PR TITLE
#216 updates to use NLU instead of NLC, from Andrew Freed and Keith H…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ There are a variety of ways to use this tool.  Primarily you will execute a k-fo
 
 [Extract and analyze Watson Assistant log data](log_analytics/README.md)
 
-## Testing Natural Language Classifier
-This tool can also be used to test a trained Natural Language Classifier (NLC). The configuration is similar to testing Watson Assistant except:
-1. Use the NLC URL in the `url` parameter (ex: `https://api.us-south.natural-language-classifier.watson.cloud.ibm.com`)
-2. Specify the `<classifier_id>` in the `workspace_id` parameter in the configuration
-3. Since NLC does not support downloading training data, the original training data must be provided if run in 'kfold' mode (using the `train_input_file` parameter)
+## Testing Natural Language Understanding Classifier
+This tool can also be used to test a trained Natural Language Understanding (NLU) Classifier. The configuration is similar to testing Watson Assistant except:
+1. Use the NLU URL in the `url` parameter (ex: `https://api.us-south.natural-language-understanding.watson.cloud.ibm.com`)
+2. Specify the `<model_id>` in the `workspace_id` parameter in the configuration
+3. Since NLU classifier does not support downloading training data, the original training data must be provided if run in 'kfold' mode (using the `train_input_file` parameter)
 
 ## General Caveats and Troubleshooting
 1. Due to different coverage among service plans, user may need to adjust `max_test_rate` accordingly to avoid network connection error.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -19,7 +19,7 @@ import csv
 import os
 import pandas as pd
 from ibm_watson import AssistantV1
-from ibm_watson import NaturalLanguageClassifierV1
+from ibm_watson import NaturalLanguageUnderstandingV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, BearerTokenAuthenticator
 
 UTF_8 = 'utf-8'
@@ -77,7 +77,7 @@ STANDARD_TEST = 'test'
 FOLD_NUM_DEFAULT = 5
 DEFAULT_WA_VERSION = '2019-02-28'
 WORKSPACE_ID_TAG = 'workspace_id'
-CLASSIFIER_ID_TAG = 'classifier_id'
+CLASSIFIER_ID_TAG = 'model_id'
 TIME_TO_WAIT = 600
 BOOL_MAP = {True: 'yes', False: 'no'}
 DEFAULT_TEST_RATE = 100
@@ -137,12 +137,13 @@ def delete_workspaces(iam_apikey, url, version, workspace_ids, auth_type, disabl
         raise ValueError(f'Unknown auth_type "{auth_type}"')
 
     for workspace_id in workspace_ids:
-        if 'natural-language-classifier' in url:
-            c = NaturalLanguageClassifierV1(
+        if 'natural-language-understanding' in url:
+            c = NaturalLanguageUnderstandingV1(
+                    version=version,
                     authenticator=authenticator
                     )
             c.set_service_url(url)
-            c.delete_classifier(classifier_id=workspace_id)
+            c.delete_classifications_model(model_id=workspace_id)
         else:
             c = AssistantV1(
                     version=version,


### PR DESCRIPTION
#216 updates to use NLU instead of NLC, from Andrew Freed and Keith Hammock Keith.Hammock@ibm.com

Signed-off-by: Andrew R Freed <afreed@us.ibm.com>

Commit set 1 is based on Python 3.9.x requirements from Watson SDK.  May require updates so that it runs on older Pythons like 3.7.x.  One issue reported with Watson SDK team that some imports don't resolve in older python:

```
from ibm_watson.natural_language_understanding_v1 import ClassificationOptions
from ibm_watson.natural_language_understanding_v1 import Features
```

Without resolution, the testing error looks like:
```
Traceback (most recent call last):
  File "/Users/afreed/Code/workspace-ibm-ghe/WA-Testing-Tool/utils/testNLC.py", line 29, in <module>
    from ibm_watson.natural_language_understanding_v1 import ClassificationOptions
ImportError: cannot import name 'ClassificationOptions' from 'ibm_watson.natural_language_understanding_v1' (/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/ibm_watson/natural_language_understanding_v1.py)
```

Need to have this resolved before merging this change set.