### PR TITLE
#215 support for Actions-based logs

### DIFF
--- a/log_analytics/README.md
+++ b/log_analytics/README.md
@@ -9,18 +9,25 @@ For more information on Watson Assistant log analysis, check out the blog series
 # getAllLogs.py
 Using a filter argument grabs a set of logs from Watson Assistant.  Specify the maximum number of log pages (`-n`) to retrieve and the maximum number of log entries per page (`-p`).
 
-This utility uses the `list_logs` API when a workspace_id is passed, otherwise uses `list_all_logs` API which requires a language and one of `request.context.system.assistant_id`, `workspace_id`, or `request.context.metadata.deployment` in the filter (see https://cloud.ibm.com/apidocs/assistant/assistant-v1?code=python#list-log-events-in-all-workspaces)
+For dialog skills, this utility uses the `list_logs` API when a workspace_id is passed, otherwise uses `list_all_logs` API which requires a language and one of `request.context.system.assistant_id`, `workspace_id`, or `request.context.metadata.deployment` in the filter (see https://cloud.ibm.com/apidocs/assistant/assistant-v1?code=python#list-log-events-in-all-workspaces)
+
+For action skills, this utility uses the `list_logs` API which requires an ID for the environment the assistant is linked to (see https://cloud.ibm.com/apidocs/assistant-v2?code=python#listlogs)
 
 The `filter` syntax is documented here: https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference
 
-Example for one workspace:
+Example for one dialog-based workspace:
 ```
 python3 getAllLogs.py -a your_api_key -w your_workspace_id -l https://gateway.watsonplatform.net/assistant/api -c raw -n 20 -p 500 -o 10000_logs.json -f "response_timestamp>=2019-11-01,response_timestamp<2019-11-21"
 ```
 
-Example for one assistant:
+Example for one dialog-based assistant (v1 API):
 ```
 python3 getAllLogs.py -a your_api_key -l https://gateway.watsonplatform.net/assistant/api -c raw -n 20 -p 500 -o 10000_logs.json -f "language::en,response_timestamp>=2019-11-01,response_timestamp<2019-11-21,request.context.system.assistant_id::your_assistant_id"
+```
+
+Example for one actions-based assistant (v2 API):
+```
+python3 getAllLogs.py -a your_api_key -e your_environment_id -l https://gateway.watsonplatform.net/assistant/api -c raw -n 20 -p 500 -o 10000_logs.json -f "response_timestamp>=2019-11-01,response_timestamp<2019-11-21"
 ```
 
 The Watson Assistant team has put out a similar script at https://github.com/watson-developer-cloud/community/blob/master/watson-assistant/export_logs.py

--- a/log_analytics/README.md
+++ b/log_analytics/README.md
@@ -44,12 +44,17 @@ Example for text-based assistants:
 python3 extractConversations.py -i 10000_logs.json -o 10000_logs.csv -c "response.context.conversation_id"
 ```
 
-Example for voice-based assistants using IBM Voice Gateway:
+Example for voice-based assistants (v2) using IBM Voice Gateway:
+```
+python3 extractConversations.py -i 10000_logs.json -o 10000_logs.csv -c "request.context.skills.main skill.user_defined.vgwSessionID"
+```
+
+Example for voice-based assistants (v1) using IBM Voice Gateway:
 ```
 python3 extractConversations.py -i 10000_logs.json -o 10000_logs.csv -c "request.context.vgwSessionID"
 ```
 
-Example for voice-based assistants that adds some useful phone-based fields
+Example for voice-based assistants (v1) that adds some useful phone-based fields
 ```
 python3 extractConversations.py -i 10000_logs.json -o 10000_logs.csv -c "request.context.vgwSessionID" -f log_id,request.context.vgwPhoneUserPhoneNumber,request.context.vgwIsDTMF,request.context.vgwBargeInOccurred
 ```

--- a/log_analytics/extractConversations.py
+++ b/log_analytics/extractConversations.py
@@ -55,7 +55,13 @@ def deep_get(dct, keys, default=None):
 
 def getFieldShortName(field_name):
     """ Simplifies `field_name` in the exported dataframe by removing Watson Assistant prefixes """
-    return field_name.replace('request.','').replace('response.','').replace('context.system.','').replace('context.','')
+    return field_name.replace('request.','')         \
+                     .replace('response.','')        \
+                     .replace('context.system.','')  \
+                     .replace('skills.','')          \
+                     .replace('main skill.','')      \
+                     .replace('user_defined.','')    \
+                     .replace('context.','')
 
 # Caches information about custom fields so they do not need to be re-calculated on every log event.
 # Example dictionary format is `{'request.response.XYZ': {'name': 'XYZ', 'key_list': ['request', 'response', 'XYZ']}}``
@@ -79,8 +85,12 @@ def logToRecord(log, customFields):
                 record['dialog_turn_counter']  = log['response']['context']['system']['dialog_turn_counter']
             else:
                 record['dialog_turn_counter']  = log['request']['context']['system']['dialog_turn_counter']
-        if 'global' in log['response']['context'] and 'dialog_turn_counter' in log['response']['context']['global']:
+        elif 'global' in log['response']['context'] and 'dialog_turn_counter' in log['response']['context']['global']:
             record['dialog_turn_counter'] = log['response']['context']['global']['dialog_turn_counter']
+        elif 'system' in log['request']['context'] and 'dialog_turn_counter' in log['request']['context']['system']:
+            record['dialog_turn_counter']  = log['request']['context']['system']['dialog_turn_counter']
+        else:
+            pass
 
         record['request_timestamp']        = log['request_timestamp']
         record['response_timestamp']       = log['response_timestamp']

--- a/log_analytics/extractConversations.py
+++ b/log_analytics/extractConversations.py
@@ -74,10 +74,13 @@ def logToRecord(log, customFields):
         record = {}
         record['conversation_id']          = log['response']['context']['conversation_id']
         #Location of dialog_turn_counter varies by WA version
-        if 'dialog_turn_counter' in log['response']['context']['system']:
-            record['dialog_turn_counter']  = log['response']['context']['system']['dialog_turn_counter']
-        else:
-            record['dialog_turn_counter']  = log['request']['context']['system']['dialog_turn_counter']
+        if 'system' in log['response']['context']:
+            if 'dialog_turn_counter' in log['response']['context']['system']:
+                record['dialog_turn_counter']  = log['response']['context']['system']['dialog_turn_counter']
+            else:
+                record['dialog_turn_counter']  = log['request']['context']['system']['dialog_turn_counter']
+        if 'global' in log['response']['context'] and 'dialog_turn_counter' in log['response']['context']['global']:
+            record['dialog_turn_counter'] = log['response']['context']['global']['dialog_turn_counter']
 
         record['request_timestamp']        = log['request_timestamp']
         record['response_timestamp']       = log['response_timestamp']
@@ -91,18 +94,26 @@ def logToRecord(log, customFields):
         if 'intents' in log['response'] and (len(log['response']['intents']) > 0):
             record['intent']               = log['response']['intents'][0]['intent']
             record['intent_confidence']    = log['response']['intents'][0]['confidence']
+        if 'output' in log['response'] and 'intents' in log['response']['output'] and (len(log['response']['output']['intents']) > 0):
+            record['intent']               = log['response']['output']['intents'][0]['intent']
+            record['intent_confidence']    = log['response']['output']['intents'][0]['confidence']
 
         if 'entities' in log['response'] and len(log['response']['entities']) > 0:
             record['entities']             = tuple ( log['response']['entities'] )
+        if 'output' in log['response'] and 'entities' in log['response']['output'] and len(log['response']['output']['entities']) > 0:
+            record['entities']             = tuple ( log['response']['output']['entities'] )
 
         if 'nodes_visited' in log['response']['output']:
             record['nodes_visited']        = tuple (log['response']['output']['nodes_visited'])
         elif 'debug' in log['response']['output'] and 'nodes_visited' in log['response']['output']['debug']:
             record['nodes_visited']        = tuple (log['response']['output']['debug']['nodes_visited'])
+        elif 'debug' in log['response']['output'] and 'turn_events' in log['response']['output']['debug']:
+            record['nodes_visited']        = getNodesVisited(log['response']['output']['debug']['turn_events'])
         else:
             record['nodes_visited']        = ()
         
-        if 'branch_exited_reason' in log['response']['context']['system']:
+        #Single variable in v1, multiple choices in v2
+        if 'system' in log['response']['context'] and 'branch_exited_reason' in log['response']['context']['system']:
             record['branch_exited_reason'] = log['response']['context']['system']['branch_exited_reason']
 
         for field in customFields:
@@ -110,6 +121,19 @@ def logToRecord(log, customFields):
             record[key]                    = deep_get(log, value)
         
         return record
+
+def getNodesVisited(turn_events):
+    nodes_visited = list()
+    for turn_event in turn_events:
+        if 'source' in turn_event and 'event' in turn_event and 'step_visited' == turn_event['event']:
+            action = turn_event['source'].get('action', None)
+            step   = turn_event['source'].get('step', None)
+            if step is None:
+                nodes_visited.append(action)
+            else:
+                nodes_visited.append(f"{action}_{step}")
+
+    return nodes_visited
 
 def extractConversationData(logs, conversation_id_key='response.context.conversation_id', custom_field_names_comma_separated=None):
     # Parse custom field names from argument list

--- a/log_analytics/getAllLogs.py
+++ b/log_analytics/getAllLogs.py
@@ -19,7 +19,7 @@ def getAssistant(ARGS):
     '''Retrieve Watson Assistant SDK object'''
     authenticator = IAMAuthenticator(iam_apikey)
 
-    if 'environment_id' in ARGS:
+    if 'environment_id' in ARGS and ARGS['environment_id'] is not None:
         c = AssistantV2(
             version=version,
             authenticator=authenticator

--- a/log_analytics/getAllLogs.py
+++ b/log_analytics/getAllLogs.py
@@ -1,6 +1,7 @@
 import json
 from argparse import ArgumentParser
 from ibm_watson import AssistantV1
+from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 import dateutil.parser
 import datetime
@@ -10,23 +11,56 @@ DEFAULT_WCS_VERSION='2018-09-20'
 DEFAULT_PAGE_SIZE=500
 DEFAULT_NUMBER_OF_PAGES=20
 
-def getAssistant(iam_apikey, url, version=DEFAULT_WCS_VERSION):
+def getAssistant(ARGS):
+    iam_apikey=ARGS['iam_apikey']
+    url=ARGS['url']
+    version=ARGS['version']
+
     '''Retrieve Watson Assistant SDK object'''
     authenticator = IAMAuthenticator(iam_apikey)
-    c = AssistantV1(
-        version=version,
-        authenticator=authenticator
-    )
+
+    if 'environment_id' in ARGS:
+        c = AssistantV2(
+            version=version,
+            authenticator=authenticator
+        )
+    else:
+        c = AssistantV1(
+            version=version,
+            authenticator=authenticator
+        )
+
     #c.set_disable_ssl_verification(True) #TODO: pass disable_ssl parameter here
     c.set_service_url(url)
     return c
 
 def getLogs(iam_apikey, url, workspace_id, filter, page_size_limit=DEFAULT_PAGE_SIZE, page_num_limit=DEFAULT_NUMBER_OF_PAGES, version=DEFAULT_WCS_VERSION):
     '''Public API for script, connects to Watson Assistant and downloads all logs'''
-    service = getAssistant(iam_apikey, url, version)
-    return getLogsInternal(service, workspace_id, filter, page_size_limit, page_num_limit)
+    ARGS = {}
+    ARGS['iam_apikey'] = iam_apikey
+    ARGS['url'] = url
+    ARGS['workspace_id'] = workspace_id
+    ARGS['filter'] = filter
+    ARGS['page_limit'] = page_size_limit
+    ARGS['number_of_pages'] = page_num_limit
+    ARGS['version'] = version
 
-def getLogsInternal(assistant, workspace_id, filter, page_size_limit=DEFAULT_PAGE_SIZE, page_num_limit=DEFAULT_NUMBER_OF_PAGES):
+    service = getAssistant(ARGS)
+    return getLogsInternal(service, ARGS)
+
+def getLogsInternal(assistant, ARGS):
+    workspace_id = None
+    if 'workspace_id' in ARGS:
+        workspace_id = ARGS['workspace_id']
+    
+    assistant_id = None
+    if 'environment_id' in ARGS:
+        assistant_id = ARGS['environment_id']
+
+    filter = ARGS['filter'] 
+    page_size_limit = ARGS['page_limit']
+    page_num_limit = ARGS['number_of_pages']
+    
     '''Fetches `page_size_limit` logs at a time through Watson Assistant log API, a maximum of `page_num_limit` times, and returns array of log events'''
     cursor = None
     pages_retrieved = 0
@@ -34,10 +68,14 @@ def getLogsInternal(assistant, workspace_id, filter, page_size_limit=DEFAULT_PAG
     noMore = False
 
     while pages_retrieved < page_num_limit and noMore != True:
-        if workspace_id is None:
-            #all - requires a workspace_id, assistant id, or deployment id in the filter
+        if assistant_id is not None:
+            #v2-based or actions
+            output = assistant.list_logs(assistant_id=assistant_id, sort='-request_timestamp', filter=filter, page_limit=page_size_limit, cursor=cursor)
+        elif workspace_id is None:
+            #v1-style, all - requires a workspace_id, assistant id, or deployment id in the filter
             output = assistant.list_all_logs(sort='-request_timestamp', filter=filter, page_limit=page_size_limit, cursor=cursor)
         else:
+            #v1-dialog
             output = assistant.list_logs(workspace_id=workspace_id, sort='-request_timestamp', filter=filter, page_limit=page_size_limit, cursor=cursor)
 
         #Hack for API compatibility between v1 and v2 of the API - v2 adds a 'result' property on the response.  v2 simplest form is list_logs().get_result()
@@ -123,7 +161,8 @@ def create_parser():
     parser = ArgumentParser(description='Extracts Watson Assistant logs from a given workspace')
     parser.add_argument('-c', '--output_columns', type=str, help='Which columns you want in output, either "utterance", "raw", or "all" (default is "raw")', default='raw')
     parser.add_argument('-o', '--output_file', type=str, help='Filename to write results to')
-    parser.add_argument('-w', '--workspace_id', type=str, help='Workspace identifier')
+    parser.add_argument('-w', '--workspace_id', type=str, help='Workspace identifier, required for Dialog skills')
+    parser.add_argument('-e', '--environment_id', type=str, help='Assistant environment identifier, required for Actions skills')
     parser.add_argument('-a', '--iam_apikey', type=str, required=True, help='Assistant service iam api key')
     parser.add_argument('-f', '--filter', type=str, required=True, help='Watson Assistant log query filter')
     parser.add_argument('-v', '--version', type=str, default=DEFAULT_WCS_VERSION, help="Watson Assistant version in YYYY-MM-DD form.")
@@ -137,6 +176,6 @@ def create_parser():
 if __name__ == '__main__':
    ARGS = create_parser().parse_args()
 
-   service = getAssistant(ARGS.iam_apikey,ARGS.url,ARGS.version)
-   logs    = getLogsInternal(service, ARGS.workspace_id, ARGS.filter, ARGS.page_limit, ARGS.number_of_pages)
+   service = getAssistant(vars(ARGS))
+   logs    = getLogsInternal(service, vars(ARGS))
    writeLogs(logs, ARGS.output_file, ARGS.output_columns)


### PR DESCRIPTION
Addresses #215 for logs

Keeps existing APIs, uses intelligent in-place toggles to deal with v1 or v2 in same branches.
v2 log fetching requires a new argument, `environment_id`, which is tied to an Assistant and an Environment

Signed-off-by: Andrew R Freed <afreed@us.ibm.com>