### PR TITLE
Export conversation in transcript format

### DIFF
--- a/log_analytics/README.md
+++ b/log_analytics/README.md
@@ -30,6 +30,11 @@ Example for one actions-based assistant (v2 API):
 python3 getAllLogs.py -a your_api_key -e your_environment_id -l https://gateway.watsonplatform.net/assistant/api -c raw -n 20 -p 500 -o 10000_logs.json -f "response_timestamp>=2019-11-01,response_timestamp<2019-11-21"
 ```
 
+Example to get logs for one conversation by conversation_id:
+```
+python3 getAllLogs.py -a your_api_key -w your_workspace_id -l https://api.xx-xxxx.assistant.watson.cloud.ibm.com/instances/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -f "response.context.conversation_id::xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -c transcript
+```
+
 The Watson Assistant team has put out a similar script at https://github.com/watson-developer-cloud/community/blob/master/watson-assistant/export_logs.py
 
 # extractConversations.py

--- a/log_analytics/getAllLogs.py
+++ b/log_analytics/getAllLogs.py
@@ -107,10 +107,12 @@ def getLogsInternal(assistant, ARGS):
 
 def writeLogs(logs, output_file, output_columns="raw"):
     '''
-    Writes log output to file system or screen.  Includes three modes:
+    Writes log output to file system or screen.  Includes four modes:
     `raw`: logs are written in JSON format
     `all`: all log columns useful for intent training are written in CSV format
     `utterance`: only the `input.text` column is written (one per line)
+    `transcript`: Alternating lines of "User" and "Watson" transcript
+
     '''
     file = None
     if output_file != None:
@@ -133,6 +135,7 @@ def writeLogs(logs, output_file, output_columns="raw"):
        confidence   = 0.0
        date         = 'unknown_date'
        last_visited = 'unknown_last_visited'
+       response     = ''
        if 'response' in log and 'intents' in log['response'] and len(log['response']['intents'])>0:
           intent     = log['response']['intents'][0]['intent']
           confidence = log['response']['intents'][0]['confidence']
@@ -141,11 +144,15 @@ def writeLogs(logs, output_file, output_columns="raw"):
           if 'nodes_visited' in log['response']['output'] and len (log['response']['output']['nodes_visited']) > 0:
              last_visited = log['response']['output']['nodes_visited'][-1]
 
+       if 'response' in log and 'output' in log['response'] and 'text' in log['response']['output'] and len(log['response']['output']['text'])>0:
+          response   = log['response']['output']['text'][0]
+
        if 'all' == output_columns:
           output_line = '{}\t{}\t{}\t{}\t{}'.format(utterance, intent, confidence, date, last_visited)
-       else:
-          #assumed just 'utterance'
+       elif 'utterance' == output_columns:
           output_line = utterance
+       else:
+          output_line = f"User: {utterance}\nWatson: {response}"
 
        writeOut(file, output_line)
 


### PR DESCRIPTION
Capability to get all logs related to a given conversation and export into transcript format.

* Tool already had ability to fetch logs for one conversation using filter string `-f "response.context.conversation_id::xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`
* Added output format for transcript between user and Watson
* Added example in README